### PR TITLE
Updated NameTag Component

### DIFF
--- a/f/common/f_nametags.sqf
+++ b/f/common/f_nametags.sqf
@@ -142,7 +142,7 @@ _ents = (position player) nearEntities [["CAManBase","LandVehicle","Helicopter",
 				_color = F_COLOR_NAMETAGS;
 				if(_x in units player) then { _color = F_COLOR_NAMETAGS_GROUP };
 
-				drawIcon3D ["", _color, [_pos select 0,_pos select 1,getPosATL _x select 2 + 2 + F_HEIGHT_NAMETAGS], 0, 0, 0, [_x] call _fnc_createString, 0,F_SIZE_NAMETAGS, F_FONT_NAMETAGS];
+				drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) + 2 + F_HEIGHT_NAMETAGS], 0, 0, 0, [_x] call _fnc_createString, 0,F_SIZE_NAMETAGS, F_FONT_NAMETAGS];
 		}
 		else
 		{


### PR DESCRIPTION
https://github.com/ferstaberinde/F3/issues/120
- added optional feature to display distance in m
- added optional feature to display type of mounted vehicle
- fixed issue where nametags of units in buildings weren't correct height
- fixed issue where nametags of enemy units in vehicles would show
