### PR TITLE
assignGear_clothes Rewrite

### DIFF
--- a/f/assignGear/f_assignGear_aaf.sqf
+++ b/f/assignGear/f_assignGear_aaf.sqf
@@ -161,10 +161,11 @@ _APmine2 = "APERSMine_Range_Mag";
 
 _light = [];
 _heavy =  ["eng","engm"];
-_divers = ["div"];
-_pilots = ["p"];
-_crews = ["c"];
+_diver = ["div"];
+_pilot = ["p"];
+_crew = ["c"];
 _ghillie = ["sn","sp"];
+_specOp = [];
 
 // Basic clothing
 // The outfit-piece is randomly selected from the array for each unit
@@ -201,6 +202,12 @@ _ghillieUniform = ["U_I_GhillieSuit"];
 _ghillieHelmet = []
 _ghillieRig = ["V_Chestrig_oli"];
 _ghillieGlasses = [];
+
+// Spec Op - no nice stuff for AAF :(
+_sfuniform = _baseUniform;
+_sfhelmet = _baseHelmet;
+_sfRig = _mediumRig;
+_sfGlasses = [];
 
 // ====================================================================================
 

--- a/f/assignGear/f_assignGear_clothes.sqf
+++ b/f/assignGear/f_assignGear_clothes.sqf
@@ -14,40 +14,55 @@ _rig = _mediumRig;
 _glasses = _baseGlasses;
 
 // Flip through unit to assign specialized uniforms
+
+// Light
 if (_typeOfUnit in _light) then {
 	_rig = _lightRig;
 };
 
+// Heavy
 if (_typeOfUnit in _heavy) then {
 	_rig = _heavyRig;
 };
 
-if (_typeOfUnit in _pilots) then {
+// Pilot
+if (_typeOfUnit in _pilot) then {
 	_helmet = _pilotHelmet;
 	_uniform = _pilotUniform;
 	_rig = _pilotRig;
 	_glasses = _pilotGlasses
 };
 
-if (_typeOfUnit in _crews) then {
+// Crew
+if (_typeOfUnit in _crew) then {
 	_helmet = _crewHelmet;
 	_uniform = _crewUniform;
 	_rig = _crewRig;
 	_glasses = _crewGlasses;
 };
 
-if (_typeOfUnit in _divers) then {
+// Diver
+if (_typeOfUnit in _diver) then {
 	_helmet = _diverHelmet;
 	_uniform = _diverUniform;
 	_rig = _diverRig;
 	_glasses = _diverGlasses;
 };
 
+// Ghillie
 if (_typeOfUnit in _ghillie) then {
 	_helmet = _ghillieHelmet;
 	_uniform = _ghillieUniform;
 	_rig = _ghillieRig;
 	_glasses = _ghillieGlasses;
+};
+
+// Spec Op
+if (_typeOfUnit in _specOp) then {
+	_helmet = _sfHelmet;
+	_uniform = _sfUniform;
+	_rig = _sfRig;
+	_glasses = _sfGlasses;
 };
 
 // Add uniforms to unit

--- a/f/assignGear/f_assignGear_csat.sqf
+++ b/f/assignGear/f_assignGear_csat.sqf
@@ -159,12 +159,13 @@ _APmine2 = "APERSMine_Range_Mag";
 // Define classes. This defines which gear class gets which uniform
 // "medium" vests are used for all classes if they are not assigned a specific uniform
 
-_light = ["sp"];
+_light = [];
 _heavy =  ["eng","engm"];
-_divers = ["div"];
-_pilots = ["p"];
-_crews = ["c"];
+_diver = ["div"];
+_pilot = ["p"];
+_crew = ["c"];
 _ghillie = ["sn","sp"];
+_specOp = [];
 
 // Basic clothing
 // The outfit-piece is randomly selected from the array for each unit
@@ -206,6 +207,13 @@ _ghillieUniform = ["U_O_GhillieSuit"];
 _ghillieHelmet = []
 _ghillieRig = ["V_Chestrig_khk"];
 _ghillieGlasses = [];
+
+// Spec Op
+_sfuniform = ["U_O_SpecopsUniform_ocamo"];
+_sfhelmet = ["H_HelmetSpecO_ocamo","H_HelmetSpecO_blk"];
+_sfRig = _mediumRig;
+_sfGlasses = [];
+
 
 // ====================================================================================
 

--- a/f/assignGear/f_assignGear_fia.sqf
+++ b/f/assignGear/f_assignGear_fia.sqf
@@ -158,12 +158,13 @@ _APmine2 = "APERSMine_Range_Mag";
 // Define classes. This defines which gear class gets which uniform
 // "medium" vests are used for all classes if they are not assigned a specific uniform
 
-_light = ["sp"];
+_light = [];
 _heavy =  ["eng","engm"];
-_divers = ["div"];
-_pilots = ["p"];
-_crews = ["c"];
+_diver = ["div"];
+_pilot = ["p"];
+_crew = ["c"];
 _ghillie = ["sn","sp"];
+_specOp = [];
 
 // Basic clothing
 // The outfit-piece is randomly selected from the array for each unit
@@ -200,6 +201,13 @@ _ghillieUniform = ["U_B_GhillieSuit"];
 _ghillieHelmet = []
 _ghillieRig = ["V_Chestrig_rgr"];
 _ghillieGlasses = [];
+
+// Spec Op (CTRG)
+_sfuniform = ["U_B_CTRG_1","U_B_CTRG_2","U_B_CTRG_3"];
+_sfhelmet = ["V_PlateCarrierL_CTRG","V_PlateCarrierH_CTRG"];
+_sfRig = _mediumRig;
+_sfGlasses = [];
+
 
 // ====================================================================================
 

--- a/f/assignGear/f_assignGear_nato.sqf
+++ b/f/assignGear/f_assignGear_nato.sqf
@@ -158,17 +158,18 @@ _APmine2 = "APERSMine_Range_Mag";
 // Define classes. This defines which gear class gets which uniform
 // "medium" vests are used for all classes if they are not assigned a specific uniform
 
-_light = ["sp"];
+_light = [];
 _heavy =  ["eng","engm"];
-_divers = ["div"];
-_pilots = ["p"];
-_crews = ["c"];
+_diver = ["div"];
+_pilot = ["p"];
+_crew = ["c"];
 _ghillie = ["sn","sp"];
+_specOp = [];
 
 // Basic clothing
 // The outfit-piece is randomly selected from the array for each unit
-_baseUniform = ["U_B_CombatUniform_mcam"];
-_baseHelmet = ["H_HelmetB"];
+_baseUniform = ["U_B_CombatUniform_mcam","U_B_CombatUniform_mcam_tshirt","U_B_CombatUniform_mcam_vest"];
+_baseHelmet = ["H_HelmetB","H_HelmetB_plain_mcamo"];
 _baseGlasses = [];
 
 // Armored vests
@@ -199,6 +200,12 @@ _ghillieUniform = ["U_B_GhillieSuit"];
 _ghillieHelmet = []
 _ghillieRig = ["V_Chestrig_rgr"];
 _ghillieGlasses = [];
+
+// Spec Op
+_sfuniform = ["U_B_SpecopsUniform_sgg"];
+_sfhelmet = ["H_HelmetSpecB","H_HelmetSpecB_paint1","H_HelmetSpecB_paint2","H_HelmetSpecB_blk"];
+_sfRig = _mediumRig;
+_sfGlasses = [];
 
 // ====================================================================================
 


### PR DESCRIPTION
- now uses a common variable to assign uniforms
- assignGear_clothes flips through _typeOfUnit (as rest of assignGear does) and overwrites the common variable where necessary
- added Ghillie & SpecOp Oufits
  - FIA uses CTRG as "Spec Op"
  - AAF doesn't get fancy Spec Op stuff
