### PR TITLE
preMount Restructure

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -359,7 +359,6 @@ class CfgFunctions
 			};
 
 			class nearPlayer{};
-			class preMount{};
 		};
 		class mpEnd
 		{
@@ -435,6 +434,11 @@ class CfgFunctions
 		{
 			file = "f\nametag";
 			class drawNameTag{};
+		};
+		class preMount
+		{
+			file = "f\preMount";
+			class mountGroups{};
 		};
 		#include "f\simplewoundingsystem\config.hpp"
 

--- a/f/preMount/fn_mountGroups.sqf
+++ b/f/preMount/fn_mountGroups.sqf
@@ -1,3 +1,7 @@
+// F3 - Mount Groups Function
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+// ====================================================================================
+
 // MAKE SURE THE SCRIPT IS ONLY RUN SERVER-SIDE
 if (!isServer) exitWith {};
 
@@ -12,15 +16,16 @@ private ["_objects","_crew","_vehs","_grps","_units"];
 // SET KEY VARIABLES
 // Using the arguments passed to the script, we first define some local variables.
 
-_vehs = _this select 0;
-_grps = _this select 1;
-_crew = if (count _this > 2) then {_this select 2} else {true};
-_fill = if (count _this > 3) then {_this select 3} else {false};
+_vehs = _this select 0;												// Array of vehicles    (objects)
+_grps = _this select 1;												// Array of group names (as strings)
+_crew = if (count _this > 2) then {_this select 2} else {true};		// Mount into crew positions? (optional - default:true)
+_fill = if (count _this > 3) then {_this select 3} else {false};	// Ignore fireteam cohesion in favor of filling vehicles? (optional - default:false)
 
 // ====================================================================================
 
 // CLEAN THE GROUP ARRAY
-// First we check if there are illegal groups in the array and fix it accordingly
+// First we check if there are illegal groups (non-existent) in the array and fix it by replacing it with a null-group.
+// At the end we remove all null-groups are removed and the array is clean
 
 if ({isNil _x} count _grps > 0) then {
 	{

--- a/mission.sqm
+++ b/mission.sqm
@@ -88,7 +88,7 @@ class Mission
 	};
 	class Groups
 	{
-		items=164;
+		items=176;
 		class Item0
 		{
 			side="WEST";
@@ -7660,9 +7660,7 @@ class Mission
 					leader=1;
 					skill=0.60000002;
 					text="F3_preMount_AAF";
-					init="[synchronizedObjects this,[""GrpAAF_ASL"",""GrpAAF_A1"",""GrpAAF_A2"",""GrpAAF_A3""],true,false] call f_fnc_preMount;";
-					syncId=0;
-					synchronizations[]={6};
+					init="[synchronizedObjects this,[""GrpAAF_ASL"",""GrpAAF_A1"",""GrpAAF_A2"",""GrpAAF_A3""],true,false] call f_fnc_mountGroups;";
 				};
 			};
 		};
@@ -7674,16 +7672,14 @@ class Mission
 				items=1;
 				class Item0
 				{
-					position[]={8450.5586,26.777582,10933.134};
+					position[]={8448.5859,26.714506,10933.794};
 					id=488;
 					side="LOGIC";
 					vehicle="Logic";
 					leader=1;
 					skill=0.60000002;
 					text="F3_preMount_NATO";
-					init="[synchronizedObjects this,[""GrpNATO_ASL"",""GrpNATO_A1"",""GrpNATO_A2"",""GrpNATO_A3""],true,false] call f_fnc_preMount;";
-					syncId=1;
-					synchronizations[]={7};
+					init="[synchronizedObjects this,[""GrpNATO_ASL"",""GrpNATO_A1"",""GrpNATO_A2"",""GrpNATO_A3""],true,false] call f_fnc_mountGroups;";
 				};
 			};
 		};
@@ -7695,7 +7691,7 @@ class Mission
 				items=1;
 				class Item0
 				{
-					position[]={8783.4482,32.194374,10886.891};
+					position[]={8784.1592,32.377594,10888.167};
 					id=489;
 					side="LOGIC";
 					vehicle="Logic";
@@ -7703,8 +7699,6 @@ class Mission
 					skill=0.60000002;
 					text="F3_preMount_CSAT";
 					init="[synchronizedObjects this,[""GrpCSAT_ASL"",""GrpCSAT_A1"",""GrpCSAT_A2"",""GrpCSAT_A3""],true,false] call f_fnc_preMount;";
-					syncId=2;
-					synchronizations[]={8};
 				};
 			};
 		};
@@ -7723,9 +7717,9 @@ class Mission
 					leader=1;
 					skill=0.60000002;
 					text="F3_preMount_OFIA";
-					init="[synchronizedObjects this,[""GrpOFIA_ASL"",""GrpOFIA_A1"",""GrpOFIA_A2"",""GrpOFIA_A3""],true,false] call f_fnc_preMount;";
-					syncId=3;
-					synchronizations[]={10,13};
+					init="[synchronizedObjects this,[""GrpOFIA_ASL"",""GrpOFIA_A1"",""GrpOFIA_A2"",""GrpOFIA_A3""],true,false] call f_fnc_mountGroups;";
+					syncId=0;
+					synchronizations[]={3,5};
 				};
 			};
 		};
@@ -7737,16 +7731,14 @@ class Mission
 				items=1;
 				class Item0
 				{
-					position[]={8491.1367,14.550704,10615.998};
+					position[]={8491.3604,14.674988,10617.672};
 					id=491;
 					side="LOGIC";
 					vehicle="Logic";
 					leader=1;
 					skill=0.60000002;
 					text="F3_preMount_FIA";
-					init="[synchronizedObjects this,[""GrpFIA_ASL"",""GrpFIA_A1"",""GrpFIA_A2"",""GrpFIA_A3""],true,false] call f_fnc_preMount;";
-					syncId=4;
-					synchronizations[]={9,12};
+					init="[synchronizedObjects this,[""GrpFIA_ASL"",""GrpFIA_A1"",""GrpFIA_A2"",""GrpFIA_A3""],true,false] call f_fnc_mountGroups;";
 				};
 			};
 		};
@@ -7765,9 +7757,9 @@ class Mission
 					leader=1;
 					skill=0.60000002;
 					text="F3_preMount_IFIA";
-					init="[synchronizedObjects this,[""GrpIFIA_ASL"",""GrpIFIA_A1"",""GrpIFIA_A2"",""GrpIFIA_A3""],true,false] call f_fnc_preMount;";
-					syncId=5;
-					synchronizations[]={11,14};
+					init="[synchronizedObjects this,[""GrpIFIA_ASL"",""GrpIFIA_A1"",""GrpIFIA_A2"",""GrpIFIA_A3""],true,false] call f_fnc_mountGroups;";
+					syncId=1;
+					synchronizations[]={4,6};
 				};
 			};
 		};
@@ -7804,14 +7796,244 @@ class Mission
 				};
 			};
 		};
+		class Item164
+		{
+			side="LOGIC";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={8805.4717,31.362656,10887.897};
+					id=495;
+					side="LOGIC";
+					vehicle="Logic";
+					leader=1;
+					skill=0.60000002;
+					text="F3_preMount_CSAT_1";
+					init="[synchronizedObjects this,[""GrpCSAT_BSL"",""GrpCSAT_B1"",""GrpCSAT_B2"",""GrpCSAT_B3""],true,false] call f_fnc_preMount;";
+				};
+			};
+		};
+		class Item165
+		{
+			side="LOGIC";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={8832.1523,30.530317,10886.891};
+					id=496;
+					side="LOGIC";
+					vehicle="Logic";
+					leader=1;
+					skill=0.60000002;
+					text="F3_preMount_CSAT_2";
+					init="[synchronizedObjects this,[""GrpCSAT_CSL"",""GrpCSAT_C1"",""GrpCSAT_C2"",""GrpCSAT_C3""],true,false] call f_fnc_preMount;";
+				};
+			};
+		};
+		class Item166
+		{
+			side="LOGIC";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={8757.7744,33.216652,10886.893};
+					id=497;
+					side="LOGIC";
+					vehicle="Logic";
+					leader=1;
+					skill=0.60000002;
+					text="F3_preMount_CSAT_3";
+					init="[synchronizedObjects this,[""GrpCSAT_CO"",""GrpCSAT_DC""],true,false] call f_fnc_preMount;";
+				};
+			};
+		};
+		class Item167
+		{
+			side="LOGIC";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={8475.9043,29.870577,10933.963};
+					id=498;
+					side="LOGIC";
+					vehicle="Logic";
+					leader=1;
+					skill=0.60000002;
+					text="F3_preMount_NATO_1";
+					init="[synchronizedObjects this,[""GrpNATO_BSL"",""GrpNATO_B1"",""GrpNATO_B2"",""GrpNATO_B3""],true,false] call f_fnc_mountGroups;";
+				};
+			};
+		};
+		class Item168
+		{
+			side="LOGIC";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={8497.668,33.35178,10934.12};
+					id=499;
+					side="LOGIC";
+					vehicle="Logic";
+					leader=1;
+					skill=0.60000002;
+					text="F3_preMount_NATO_2";
+					init="[synchronizedObjects this,[""GrpNATO_CSL"",""GrpNATO_C1"",""GrpNATO_C2"",""GrpNATO_C3""],true,false] call f_fnc_mountGroups;";
+				};
+			};
+		};
+		class Item169
+		{
+			side="LOGIC";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={8424.251,24.491131,10933.396};
+					id=500;
+					side="LOGIC";
+					vehicle="Logic";
+					leader=1;
+					skill=0.60000002;
+					text="F3_preMount_NATO_3";
+					init="[synchronizedObjects this,[""GrpNATO_CO"",""GrpNATO_DC""],true,false] call f_fnc_mountGroups;";
+				};
+			};
+		};
+		class Item170
+		{
+			side="LOGIC";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={7974.2783,27.342405,10869.536};
+					id=501;
+					side="LOGIC";
+					vehicle="Logic";
+					leader=1;
+					skill=0.60000002;
+					text="F3_preMount_AAF_1";
+					init="[synchronizedObjects this,[""GrpAAF_BSL"",""GrpAAF_B1"",""GrpAAF_B2"",""GrpAAF_B3""],true,false] call f_fnc_mountGroups;";
+				};
+			};
+		};
+		class Item171
+		{
+			side="LOGIC";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={8000.1079,25.922478,10870.959};
+					id=502;
+					side="LOGIC";
+					vehicle="Logic";
+					leader=1;
+					skill=0.60000002;
+					text="F3_preMount_AAF_2";
+					init="[synchronizedObjects this,[""GrpAAF_CSL"",""GrpAAF_C1"",""GrpAAF_C2"",""GrpAAF_C3""],true,false] call f_fnc_mountGroups;";
+				};
+			};
+		};
+		class Item172
+		{
+			side="LOGIC";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={7927.3682,27.352558,10868.294};
+					id=503;
+					side="LOGIC";
+					vehicle="Logic";
+					leader=1;
+					skill=0.60000002;
+					text="F3_preMount_AAF_3";
+					init="[synchronizedObjects this,[""GrpAAF_CO"",""GrpAAF_DC""],true,false] call f_fnc_mountGroups;";
+				};
+			};
+		};
+		class Item173
+		{
+			side="LOGIC";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={8517.7031,14.12731,10617.561};
+					id=504;
+					side="LOGIC";
+					vehicle="Logic";
+					leader=1;
+					skill=0.60000002;
+					text="F3_preMount_FIA_1";
+					init="[synchronizedObjects this,[""GrpFIA_BSL"",""GrpFIA_B1"",""GrpFIA_B2"",""GrpFIA_B3""],true,false] call f_fnc_mountGroups;";
+				};
+			};
+		};
+		class Item174
+		{
+			side="LOGIC";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={8540.6973,14.009458,10620.237};
+					id=505;
+					side="LOGIC";
+					vehicle="Logic";
+					leader=1;
+					skill=0.60000002;
+					text="F3_preMount_FIA_2";
+					init="[synchronizedObjects this,[""GrpFIA_CSL"",""GrpFIA_C1"",""GrpFIA_C2"",""GrpFIA_C3""],true,false] call f_fnc_mountGroups;";
+					syncId=2;
+					synchronizations[]={2};
+				};
+			};
+		};
+		class Item175
+		{
+			side="LOGIC";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={8468.8135,14.149327,10618.031};
+					id=506;
+					side="LOGIC";
+					vehicle="Logic";
+					leader=1;
+					skill=0.60000002;
+					text="F3_preMount_FIA_3";
+					init="[synchronizedObjects this,[""GrpFIA_CO"",""GrpFIA_DC""],true,false] call f_fnc_mountGroups;";
+				};
+			};
+		};
 	};
 	class Vehicles
 	{
-		items=83;
+		items=86;
 		class Item0
 		{
 			position[]={8448.3682,22.231026,10822.729};
-			id=495;
+			id=507;
 			side="EMPTY";
 			vehicle="B_Heli_Transport_01_F";
 			leader=1;
@@ -7821,7 +8043,7 @@ class Mission
 		class Item1
 		{
 			position[]={8789.0449,25.681644,10783.284};
-			id=496;
+			id=508;
 			side="EMPTY";
 			vehicle="O_Heli_Light_02_unarmed_F";
 			skill=0.60000002;
@@ -7830,7 +8052,7 @@ class Mission
 		class Item2
 		{
 			position[]={7949.9307,39.657188,10764.282};
-			id=497;
+			id=509;
 			side="EMPTY";
 			vehicle="I_Heli_Transport_02_F";
 			leader=1;
@@ -7840,7 +8062,7 @@ class Mission
 		class Item3
 		{
 			position[]={8448.1592,21.198637,10799.869};
-			id=498;
+			id=510;
 			side="EMPTY";
 			vehicle="B_Heli_Transport_01_F";
 			leader=1;
@@ -7850,7 +8072,7 @@ class Mission
 		class Item4
 		{
 			position[]={8472.4619,25.62302,10822.854};
-			id=499;
+			id=511;
 			side="EMPTY";
 			vehicle="B_Heli_Transport_01_F";
 			leader=1;
@@ -7860,7 +8082,7 @@ class Mission
 		class Item5
 		{
 			position[]={8472.7627,24.616396,10800.423};
-			id=500;
+			id=512;
 			side="EMPTY";
 			vehicle="B_Heli_Transport_01_F";
 			leader=1;
@@ -7870,7 +8092,7 @@ class Mission
 		class Item6
 		{
 			position[]={8499.2178,28.329477,10823.107};
-			id=501;
+			id=513;
 			side="EMPTY";
 			vehicle="B_Heli_Transport_01_F";
 			leader=1;
@@ -7880,7 +8102,7 @@ class Mission
 		class Item7
 		{
 			position[]={8499.0088,27.19895,10800.252};
-			id=502;
+			id=514;
 			side="EMPTY";
 			vehicle="B_Heli_Transport_01_F";
 			leader=1;
@@ -7890,7 +8112,7 @@ class Mission
 		class Item8
 		{
 			position[]={8523.3115,30.137499,10823.236};
-			id=503;
+			id=515;
 			side="EMPTY";
 			vehicle="B_Heli_Transport_01_F";
 			leader=1;
@@ -7900,7 +8122,7 @@ class Mission
 		class Item9
 		{
 			position[]={8523.6123,29.744282,10800.803};
-			id=504;
+			id=516;
 			side="EMPTY";
 			vehicle="B_Heli_Transport_01_F";
 			leader=1;
@@ -7910,7 +8132,7 @@ class Mission
 		class Item10
 		{
 			position[]={8438.5361,18.926207,10776.412};
-			id=505;
+			id=517;
 			side="EMPTY";
 			vehicle="B_APC_Wheeled_01_cannon_F";
 			skill=0.60000002;
@@ -7920,7 +8142,7 @@ class Mission
 		class Item11
 		{
 			position[]={8450.9932,19.721678,10772.795};
-			id=506;
+			id=518;
 			side="EMPTY";
 			vehicle="B_APC_Wheeled_01_cannon_F";
 			skill=0.60000002;
@@ -7930,7 +8152,7 @@ class Mission
 		class Item12
 		{
 			position[]={8466.6533,22.128168,10776.298};
-			id=507;
+			id=519;
 			side="EMPTY";
 			vehicle="B_APC_Wheeled_01_cannon_F";
 			skill=0.60000002;
@@ -7940,7 +8162,7 @@ class Mission
 		class Item13
 		{
 			position[]={8479.1104,23.818899,10772.686};
-			id=508;
+			id=520;
 			side="EMPTY";
 			vehicle="B_APC_Wheeled_01_cannon_F";
 			skill=0.60000002;
@@ -7950,7 +8172,7 @@ class Mission
 		class Item14
 		{
 			position[]={8493.2002,25.658817,10776.811};
-			id=509;
+			id=521;
 			side="EMPTY";
 			vehicle="B_APC_Wheeled_01_cannon_F";
 			skill=0.60000002;
@@ -7960,7 +8182,7 @@ class Mission
 		class Item15
 		{
 			position[]={8505.6572,27.185215,10773.197};
-			id=510;
+			id=522;
 			side="EMPTY";
 			vehicle="B_APC_Wheeled_01_cannon_F";
 			skill=0.60000002;
@@ -7970,7 +8192,7 @@ class Mission
 		class Item16
 		{
 			position[]={8521.3174,28.977724,10776.697};
-			id=511;
+			id=523;
 			side="EMPTY";
 			vehicle="B_APC_Wheeled_01_cannon_F";
 			skill=0.60000002;
@@ -7980,7 +8202,7 @@ class Mission
 		class Item17
 		{
 			position[]={8533.7744,28.381733,10773.084};
-			id=512;
+			id=524;
 			side="EMPTY";
 			vehicle="B_APC_Wheeled_01_cannon_F";
 			skill=0.60000002;
@@ -7990,7 +8212,7 @@ class Mission
 		class Item18
 		{
 			position[]={8425.8682,19.107016,10822.307};
-			id=513;
+			id=525;
 			side="EMPTY";
 			vehicle="B_Heli_Attack_01_F";
 			leader=1;
@@ -8000,7 +8222,7 @@ class Mission
 		class Item19
 		{
 			position[]={7974.2783,39.779701,10764.282};
-			id=514;
+			id=526;
 			side="EMPTY";
 			vehicle="I_Heli_Transport_02_F";
 			leader=1;
@@ -8010,7 +8232,7 @@ class Mission
 		class Item20
 		{
 			position[]={8002.1768,37.100895,10764.661};
-			id=515;
+			id=527;
 			side="EMPTY";
 			vehicle="I_Heli_Transport_02_F";
 			leader=1;
@@ -8020,7 +8242,7 @@ class Mission
 		class Item21
 		{
 			position[]={8026.5244,33.952877,10764.661};
-			id=516;
+			id=528;
 			side="EMPTY";
 			vehicle="I_Heli_Transport_02_F";
 			leader=1;
@@ -8030,7 +8252,7 @@ class Mission
 		class Item22
 		{
 			position[]={8788.1895,24.893557,10757.491};
-			id=517;
+			id=529;
 			side="EMPTY";
 			vehicle="O_Heli_Light_02_unarmed_F";
 			skill=0.60000002;
@@ -8039,7 +8261,7 @@ class Mission
 		class Item23
 		{
 			position[]={8815.1465,28.272205,10783.55};
-			id=518;
+			id=530;
 			side="EMPTY";
 			vehicle="O_Heli_Light_02_unarmed_F";
 			skill=0.60000002;
@@ -8048,7 +8270,7 @@ class Mission
 		class Item24
 		{
 			position[]={8814.291,26.253496,10757.757};
-			id=519;
+			id=531;
 			side="EMPTY";
 			vehicle="O_Heli_Light_02_unarmed_F";
 			skill=0.60000002;
@@ -8057,7 +8279,7 @@ class Mission
 		class Item25
 		{
 			position[]={8840.7832,29.215569,10783.62};
-			id=520;
+			id=532;
 			side="EMPTY";
 			vehicle="O_Heli_Light_02_unarmed_F";
 			skill=0.60000002;
@@ -8066,7 +8288,7 @@ class Mission
 		class Item26
 		{
 			position[]={8839.9277,27.958111,10757.827};
-			id=521;
+			id=533;
 			side="EMPTY";
 			vehicle="O_Heli_Light_02_unarmed_F";
 			skill=0.60000002;
@@ -8075,7 +8297,7 @@ class Mission
 		class Item27
 		{
 			position[]={8866.8809,30.203314,10783.886};
-			id=522;
+			id=534;
 			side="EMPTY";
 			vehicle="O_Heli_Light_02_unarmed_F";
 			skill=0.60000002;
@@ -8084,7 +8306,7 @@ class Mission
 		class Item28
 		{
 			position[]={8866.0254,29.259983,10758.093};
-			id=523;
+			id=535;
 			side="EMPTY";
 			vehicle="O_Heli_Light_02_unarmed_F";
 			skill=0.60000002;
@@ -8093,7 +8315,7 @@ class Mission
 		class Item29
 		{
 			position[]={8781.9473,25.22014,10721.64};
-			id=524;
+			id=536;
 			side="EMPTY";
 			vehicle="O_APC_Wheeled_02_rcws_F";
 			leader=1;
@@ -8104,7 +8326,7 @@ class Mission
 		class Item30
 		{
 			position[]={8792.8066,25.262209,10714.558};
-			id=525;
+			id=537;
 			side="EMPTY";
 			vehicle="O_APC_Wheeled_02_rcws_F";
 			leader=1;
@@ -8115,7 +8337,7 @@ class Mission
 		class Item31
 		{
 			position[]={8808.6055,25.62203,10721.304};
-			id=526;
+			id=538;
 			side="EMPTY";
 			vehicle="O_APC_Wheeled_02_rcws_F";
 			leader=1;
@@ -8126,7 +8348,7 @@ class Mission
 		class Item32
 		{
 			position[]={8819.459,25.832487,10714.222};
-			id=527;
+			id=539;
 			side="EMPTY";
 			vehicle="O_APC_Wheeled_02_rcws_F";
 			leader=1;
@@ -8137,7 +8359,7 @@ class Mission
 		class Item33
 		{
 			position[]={8833.9414,26.245571,10720.753};
-			id=528;
+			id=540;
 			side="EMPTY";
 			vehicle="O_APC_Wheeled_02_rcws_F";
 			leader=1;
@@ -8148,7 +8370,7 @@ class Mission
 		class Item34
 		{
 			position[]={8844.7998,27.057308,10713.671};
-			id=529;
+			id=541;
 			side="EMPTY";
 			vehicle="O_APC_Wheeled_02_rcws_F";
 			leader=1;
@@ -8159,7 +8381,7 @@ class Mission
 		class Item35
 		{
 			position[]={8860.5957,27.738935,10720.413};
-			id=530;
+			id=542;
 			side="EMPTY";
 			vehicle="O_APC_Wheeled_02_rcws_F";
 			leader=1;
@@ -8170,7 +8392,7 @@ class Mission
 		class Item36
 		{
 			position[]={8871.4512,28.152693,10713.331};
-			id=531;
+			id=543;
 			side="EMPTY";
 			vehicle="O_APC_Wheeled_02_rcws_F";
 			leader=1;
@@ -8181,7 +8403,7 @@ class Mission
 		class Item37
 		{
 			position[]={8756.5449,24.576647,10784.448};
-			id=532;
+			id=544;
 			side="EMPTY";
 			vehicle="O_Heli_Attack_02_F";
 			skill=0.60000002;
@@ -8190,7 +8412,7 @@ class Mission
 		class Item38
 		{
 			position[]={8416.9307,16.396641,10777.588};
-			id=533;
+			id=545;
 			side="EMPTY";
 			vehicle="B_MBT_01_cannon_F";
 			skill=0.60000002;
@@ -8199,7 +8421,7 @@ class Mission
 		class Item39
 		{
 			position[]={7942.1846,39.595757,10732.091};
-			id=534;
+			id=546;
 			side="EMPTY";
 			vehicle="I_APC_Wheeled_03_cannon_F";
 			leader=1;
@@ -8210,7 +8432,7 @@ class Mission
 		class Item40
 		{
 			position[]={7955.1084,39.345966,10729.411};
-			id=535;
+			id=547;
 			side="EMPTY";
 			vehicle="I_APC_Wheeled_03_cannon_F";
 			leader=1;
@@ -8221,7 +8443,7 @@ class Mission
 		class Item41
 		{
 			position[]={7970.0596,38.598431,10731.626};
-			id=536;
+			id=548;
 			side="EMPTY";
 			vehicle="I_APC_Wheeled_03_cannon_F";
 			leader=1;
@@ -8232,7 +8454,7 @@ class Mission
 		class Item42
 		{
 			position[]={7983.2041,38.260025,10729.47};
-			id=537;
+			id=549;
 			side="EMPTY";
 			vehicle="I_APC_Wheeled_03_cannon_F";
 			leader=1;
@@ -8243,7 +8465,7 @@ class Mission
 		class Item43
 		{
 			position[]={7997.1729,38.341164,10731.716};
-			id=538;
+			id=550;
 			side="EMPTY";
 			vehicle="I_APC_Wheeled_03_cannon_F";
 			leader=1;
@@ -8254,7 +8476,7 @@ class Mission
 		class Item44
 		{
 			position[]={8009.4736,36.704266,10729.716};
-			id=539;
+			id=551;
 			side="EMPTY";
 			vehicle="I_APC_Wheeled_03_cannon_F";
 			leader=1;
@@ -8265,7 +8487,7 @@ class Mission
 		class Item45
 		{
 			position[]={8025.1084,32.219151,10731.665};
-			id=540;
+			id=552;
 			side="EMPTY";
 			vehicle="I_APC_Wheeled_03_cannon_F";
 			leader=1;
@@ -8276,7 +8498,7 @@ class Mission
 		class Item46
 		{
 			position[]={8037.4385,31.284,10729.38};
-			id=541;
+			id=553;
 			side="EMPTY";
 			vehicle="I_APC_Wheeled_03_cannon_F";
 			leader=1;
@@ -8287,7 +8509,7 @@ class Mission
 		class Item47
 		{
 			position[]={8764.6074,24.156652,10724.003};
-			id=542;
+			id=554;
 			side="EMPTY";
 			vehicle="O_MBT_02_cannon_F";
 			skill=0.60000002;
@@ -8296,7 +8518,7 @@ class Mission
 		class Item48
 		{
 			position[]={7949.6494,40.644352,10708.679};
-			id=543;
+			id=555;
 			side="EMPTY";
 			vehicle="I_MBT_03_cannon_F";
 			leader=1;
@@ -8306,7 +8528,7 @@ class Mission
 		class Item49
 		{
 			position[]={7922.8633,35.427017,10779.894};
-			id=544;
+			id=556;
 			side="EMPTY";
 			vehicle="I_Heli_light_03_F";
 			leader=1;
@@ -8316,19 +8538,17 @@ class Mission
 		class Item50
 		{
 			position[]={7950.1069,27.283443,10856.785};
-			id=545;
+			id=557;
 			side="EMPTY";
 			vehicle="I_Truck_02_transport_F";
 			skill=0.60000002;
 			text="VehAAF_Tr1";
 			init="[""v_tr"",this] call f_fnc_assignGear";
-			syncId=6;
-			synchronizations[]={0};
 		};
 		class Item51
 		{
 			position[]={7976.4429,29.305141,10856.967};
-			id=546;
+			id=558;
 			side="EMPTY";
 			vehicle="I_Truck_02_transport_F";
 			skill=0.60000002;
@@ -8338,7 +8558,7 @@ class Mission
 		class Item52
 		{
 			position[]={8000.7954,27.408833,10857.867};
-			id=547;
+			id=559;
 			side="EMPTY";
 			vehicle="I_Truck_02_transport_F";
 			skill=0.60000002;
@@ -8347,8 +8567,8 @@ class Mission
 		};
 		class Item53
 		{
-			position[]={7927.3784,28.538065,10856.241};
-			id=548;
+			position[]={7920.4941,28.96537,10840.768};
+			id=560;
 			side="EMPTY";
 			vehicle="I_MRAP_03_F";
 			skill=0.60000002;
@@ -8357,8 +8577,8 @@ class Mission
 		};
 		class Item54
 		{
-			position[]={8424.8936,23.808683,10915.519};
-			id=549;
+			position[]={8415.4541,22.126028,10900.159};
+			id=561;
 			side="EMPTY";
 			vehicle="B_MRAP_01_F";
 			skill=0.60000002;
@@ -8368,19 +8588,17 @@ class Mission
 		class Item55
 		{
 			position[]={8450.5088,26.644569,10916.959};
-			id=550;
+			id=562;
 			side="EMPTY";
 			vehicle="B_Truck_01_transport_F";
 			skill=0.60000002;
 			text="VehNato_Tr1";
 			init="[""v_tr"",this] call f_fnc_assignGear";
-			syncId=7;
-			synchronizations[]={1};
 		};
 		class Item56
 		{
 			position[]={8474.1289,29.160395,10915.582};
-			id=551;
+			id=563;
 			side="EMPTY";
 			vehicle="B_Truck_01_transport_F";
 			skill=0.60000002;
@@ -8390,7 +8608,7 @@ class Mission
 		class Item57
 		{
 			position[]={8497.9775,31.999403,10916.728};
-			id=552;
+			id=564;
 			side="EMPTY";
 			vehicle="B_Truck_01_transport_F";
 			skill=0.60000002;
@@ -8399,8 +8617,8 @@ class Mission
 		};
 		class Item58
 		{
-			position[]={8758.3906,31.56374,10869.459};
-			id=553;
+			position[]={8748.3926,31.220297,10854.311};
+			id=565;
 			side="EMPTY";
 			vehicle="O_MRAP_02_F";
 			skill=0.60000002;
@@ -8410,19 +8628,17 @@ class Mission
 		class Item59
 		{
 			position[]={8784.0059,31.022173,10870.899};
-			id=554;
+			id=566;
 			side="EMPTY";
 			vehicle="O_Truck_03_transport_F";
 			skill=0.60000002;
 			text="VehCSAT_Tr1";
 			init="[""v_tr"",this] call f_fnc_assignGear";
-			syncId=8;
-			synchronizations[]={2};
 		};
 		class Item60
 		{
 			position[]={8806.9375,29.901438,10870.671};
-			id=555;
+			id=567;
 			side="EMPTY";
 			vehicle="O_Truck_03_transport_F";
 			skill=0.60000002;
@@ -8432,7 +8648,7 @@ class Mission
 		class Item61
 		{
 			position[]={8832.8516,30.450958,10871.128};
-			id=556;
+			id=568;
 			side="EMPTY";
 			vehicle="O_Truck_03_transport_F";
 			skill=0.60000002;
@@ -8441,8 +8657,8 @@ class Mission
 		};
 		class Item62
 		{
-			position[]={8469.7617,14.391917,10610.215};
-			id=557;
+			position[]={8469.3838,14.576154,10606.44};
+			id=569;
 			side="EMPTY";
 			vehicle="B_G_Offroad_01_F";
 			skill=0.60000002;
@@ -8452,19 +8668,17 @@ class Mission
 		class Item63
 		{
 			position[]={8487.5,14.942591,10609.504};
-			id=558;
+			id=570;
 			side="EMPTY";
 			vehicle="B_G_Offroad_01_F";
 			skill=0.60000002;
 			text="VehFIA_Car2";
 			init="[""v_car"",this] call f_fnc_assignGear";
-			syncId=9;
-			synchronizations[]={4};
 		};
 		class Item64
 		{
 			position[]={8514.4609,14.145928,10609.79};
-			id=559;
+			id=571;
 			side="EMPTY";
 			vehicle="B_G_Offroad_01_F";
 			skill=0.60000002;
@@ -8474,7 +8688,7 @@ class Mission
 		class Item65
 		{
 			position[]={8540.4268,14.11809,10606.099};
-			id=560;
+			id=572;
 			side="EMPTY";
 			vehicle="B_G_Offroad_01_F";
 			skill=0.60000002;
@@ -8484,7 +8698,7 @@ class Mission
 		class Item66
 		{
 			position[]={8767.8945,35.531475,10588.09};
-			id=561;
+			id=573;
 			side="EMPTY";
 			vehicle="O_G_Offroad_01_F";
 			skill=0.60000002;
@@ -8494,19 +8708,19 @@ class Mission
 		class Item67
 		{
 			position[]={8785.6328,32.92749,10587.379};
-			id=562;
+			id=574;
 			side="EMPTY";
 			vehicle="O_G_Offroad_01_F";
 			skill=0.60000002;
 			text="VehOFIA_Car2";
 			init="[""v_car"",this] call f_fnc_assignGear";
-			syncId=10;
-			synchronizations[]={3};
+			syncId=3;
+			synchronizations[]={0};
 		};
 		class Item68
 		{
 			position[]={8812.5938,32.441277,10587.665};
-			id=563;
+			id=575;
 			side="EMPTY";
 			vehicle="O_G_Offroad_01_F";
 			skill=0.60000002;
@@ -8516,7 +8730,7 @@ class Mission
 		class Item69
 		{
 			position[]={8838.5596,32.839325,10583.974};
-			id=564;
+			id=576;
 			side="EMPTY";
 			vehicle="O_G_Offroad_01_F";
 			skill=0.60000002;
@@ -8525,8 +8739,8 @@ class Mission
 		};
 		class Item70
 		{
-			position[]={7934.7954,46.116558,10638.713};
-			id=565;
+			position[]={7927.8657,46.039055,10624.656};
+			id=577;
 			side="EMPTY";
 			vehicle="I_G_Offroad_01_armed_F";
 			skill=0.60000002;
@@ -8536,19 +8750,19 @@ class Mission
 		class Item71
 		{
 			position[]={7952.5337,45.97842,10638.002};
-			id=566;
+			id=578;
 			side="EMPTY";
 			vehicle="I_G_Offroad_01_armed_F";
 			skill=0.60000002;
 			text="VehIFIA_Car2";
 			init="[""v_car"",this] call f_fnc_assignGear";
-			syncId=11;
-			synchronizations[]={5};
+			syncId=4;
+			synchronizations[]={1};
 		};
 		class Item72
 		{
 			position[]={7979.4946,43.605087,10638.288};
-			id=567;
+			id=579;
 			side="EMPTY";
 			vehicle="I_G_Offroad_01_armed_F";
 			skill=0.60000002;
@@ -8558,7 +8772,7 @@ class Mission
 		class Item73
 		{
 			position[]={8005.4604,38.99054,10634.597};
-			id=568;
+			id=580;
 			side="EMPTY";
 			vehicle="I_G_Offroad_01_armed_F";
 			skill=0.60000002;
@@ -8568,19 +8782,17 @@ class Mission
 		class Item74
 		{
 			position[]={8496.6533,14.734678,10608.534};
-			id=569;
+			id=581;
 			side="EMPTY";
 			vehicle="B_G_Van_01_transport_F";
 			skill=0.60000002;
 			text="VehFIA_Tr1";
 			init="[""v_tr"",this] call f_fnc_assignGear";
-			syncId=12;
-			synchronizations[]={4};
 		};
 		class Item75
 		{
 			position[]={8519.9375,14.11479,10608.343};
-			id=570;
+			id=582;
 			side="EMPTY";
 			vehicle="B_G_Van_01_transport_F";
 			skill=0.60000002;
@@ -8590,7 +8802,7 @@ class Mission
 		class Item76
 		{
 			position[]={8545.6201,14.223547,10606.498};
-			id=571;
+			id=583;
 			side="EMPTY";
 			vehicle="B_G_Van_01_transport_F";
 			skill=0.60000002;
@@ -8600,19 +8812,19 @@ class Mission
 		class Item77
 		{
 			position[]={8794.7861,32.190674,10586.409};
-			id=572;
+			id=584;
 			side="EMPTY";
 			vehicle="B_G_Van_01_transport_F";
 			skill=0.60000002;
 			text="VehOFIA_Tr1";
 			init="[""v_tr"",this] call f_fnc_assignGear";
-			syncId=13;
-			synchronizations[]={3};
+			syncId=5;
+			synchronizations[]={0};
 		};
 		class Item78
 		{
 			position[]={8818.0703,32.926289,10586.218};
-			id=573;
+			id=585;
 			side="EMPTY";
 			vehicle="B_G_Van_01_transport_F";
 			skill=0.60000002;
@@ -8622,7 +8834,7 @@ class Mission
 		class Item79
 		{
 			position[]={8843.7529,32.731731,10584.373};
-			id=574;
+			id=586;
 			side="EMPTY";
 			vehicle="B_G_Van_01_transport_F";
 			skill=0.60000002;
@@ -8632,19 +8844,19 @@ class Mission
 		class Item80
 		{
 			position[]={7961.687,46.043327,10637.032};
-			id=575;
+			id=587;
 			side="EMPTY";
 			vehicle="B_G_Van_01_transport_F";
 			skill=0.60000002;
 			text="VehIFIA_Tr1";
 			init="[""v_tr"",this] call f_fnc_assignGear";
-			syncId=14;
-			synchronizations[]={5};
+			syncId=6;
+			synchronizations[]={1};
 		};
 		class Item81
 		{
 			position[]={7984.9712,43.019047,10636.841};
-			id=576;
+			id=588;
 			side="EMPTY";
 			vehicle="B_G_Van_01_transport_F";
 			skill=0.60000002;
@@ -8654,12 +8866,42 @@ class Mission
 		class Item82
 		{
 			position[]={8010.6538,37.976051,10634.996};
-			id=577;
+			id=589;
 			side="EMPTY";
 			vehicle="B_G_Van_01_transport_F";
 			skill=0.60000002;
 			text="VehIFIA_Tr3";
 			init="[""v_tr"",this] call f_fnc_assignGear";
+		};
+		class Item83
+		{
+			position[]={7918.5835,29.918686,10826.28};
+			id=590;
+			side="EMPTY";
+			vehicle="I_MRAP_03_F";
+			skill=0.60000002;
+			text="VehAAF_Car2";
+			init="[""v_car"",this] call f_fnc_assignGear";
+		};
+		class Item84
+		{
+			position[]={8747.3027,29.745636,10835.602};
+			id=591;
+			side="EMPTY";
+			vehicle="O_MRAP_02_F";
+			skill=0.60000002;
+			text="VehCSAT_Car2";
+			init="[""v_car"",this] call f_fnc_assignGear";
+		};
+		class Item85
+		{
+			position[]={8415.4531,21.373798,10883.677};
+			id=592;
+			side="EMPTY";
+			vehicle="B_MRAP_01_F";
+			skill=0.60000002;
+			text="VehNato_Car2";
+			init="[""v_car"",this] call f_fnc_assignGear";
 		};
 	};
 	class Markers


### PR DESCRIPTION
- moved to f\preMount
- renamed function to f_fnc_mountGroups to better reflect functionality
- added 2nd car to NATO/CSAT/AAF orbats
- added pre-placed modules for all factions
- de-synced modules for alpha squads (no squads are premounted by default now - MM have to sync the modules to activate it)
