### PR TITLE
Added additional RPGs for RATs

### DIFF
--- a/f/assignGear/f_assignGear_aaf_b.sqf
+++ b/f/assignGear/f_assignGear_aaf_b.sqf
@@ -5,7 +5,7 @@
 // BACKPACK: MEDIC
 case "m":
 {
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks <= 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -14,7 +14,7 @@ case "m":
 		(unitBackpack _unit) addItemCargoGlobal [_firstaid, 4];
 	};
 
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -27,7 +27,7 @@ case "m":
 // BACKPACK: GRENADIER (CO/DC/SL/FTL/G)
 case "g":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_glriflemag,2];
 		_unit addmagazines [_glmag,1];
@@ -35,7 +35,7 @@ case "g":
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,2];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -46,7 +46,7 @@ case "g":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -62,11 +62,11 @@ case "g":
 // BACKPACK: AR
 case "ar":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_ARmag_Tr,1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -76,7 +76,7 @@ case "ar":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -91,14 +91,14 @@ case "ar":
 // BACKPACK: AAR
 case "aar":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_ARmag,1];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,1];
 	};
 
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -108,7 +108,7 @@ case "aar":
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_ARmag, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -124,13 +124,13 @@ case "aar":
 // BACKPACK: RIFLEMAN AT (RAT)
 case "rat":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR ROCKETS)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 	};
 
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -138,14 +138,15 @@ case "rat":
 		(unitBackpack _unit) addMagazineCargoGlobal [_grenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
+		(unitBackpack _unit) addMagazineCargoGlobal [_RATmag, 1];
 
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag, 4];
-		(unitBackpack _unit) addMagazineCargoGlobal [_RATmag, 1];
+		(unitBackpack _unit) addMagazineCargoGlobal [_RATmag, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_grenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
@@ -155,7 +156,7 @@ case "rat":
 // BACKPACK: RIFLEMAN (R)
 case "r":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_riflemag,2];
 		_unit addmagazines [_grenade,1];
@@ -163,7 +164,7 @@ case "r":
 		_unit addmagazines [_smokegrenade,2];
 	};
 
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -172,7 +173,7 @@ case "r":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -187,14 +188,14 @@ case "r":
 // BACKPACK: CARABINEER (CAR)
 case "car":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_carbinemag,2];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,2];
 	};
 
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -203,7 +204,7 @@ case "car":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -218,13 +219,13 @@ case "car":
 // BACKPACK: MMG GUNNER (MMG)
 case "mmg":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_MMGmag,1];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -233,7 +234,7 @@ case "mmg":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -245,13 +246,13 @@ case "mmg":
 	};
 };
 
-// BACKPACK: HEAVY MG GUNNER (HMGG)
+// LOADOUT: HEAVY MG GUNNER (HMGG)
 case "hmgg":
 {
 	_unit addBackpack _baghmgg;
 };
 
-// BACKPACK: HEAVY MG ASSISTANT GUNNER (HMGAG)
+// LOADOUT: HEAVY MG ASSISTANT GUNNER (HMGAG)
 case "hmgag":
 {
 	_unit addBackpack _baghmgag;
@@ -260,13 +261,13 @@ case "hmgag":
 // BACKPACK: MMG ASSISTANT GUNNER (MMGAG)
 case "mmgag":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_MMGmag,1];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -278,7 +279,7 @@ case "mmgag":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -295,7 +296,7 @@ case "mmgag":
 // BACKPACK: MAT GUNNER (MATG)
 case "matg":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR ROCKETS)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -306,7 +307,7 @@ case "matg":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -317,7 +318,7 @@ case "matg":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -333,7 +334,7 @@ case "matg":
 // BACKPACK: MAT ASSISTANT (MATAG)
 case "matag":
     {
-	// NO BACKPACK (STILL ADD SMALL FOR ROCKETS)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -343,7 +344,7 @@ case "matag":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -354,7 +355,7 @@ case "matag":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -366,13 +367,13 @@ case "matag":
 	};
 };
 
-// BACKPACK: HEAVY AT GUNNER (HATG)
+// LOADOUT: HEAVY AT GUNNER (HATG)
 case "hatg":
 {
 	_unit addBackpack _baghatg;
 };
 
-// BACKPACK: HEAVY AT ASSISTANT GUNNER (HATAG)
+// LOADOUT: HEAVY AT ASSISTANT GUNNER (HATAG)
 case "hatag":
 {
 	_unit addBackpack _baghatag;
@@ -406,13 +407,13 @@ case "msamag":
 	(unitBackpack _unit) addMagazineCargoGlobal [_SAMmag, 2];
 };
 
-// BACKPACK: HEAVY SAM GUNNER (HSAMG)
+// LOADOUT: HEAVY SAM GUNNER (HSAMG)
 case "hsamg":
 {
 	_unit addBackpack _baghsamg;
 };
 
-// BACKPACK: HEAVY SAM ASSISTANT GUNNER (HSAMAG)
+// LOADOUT: HEAVY SAM ASSISTANT GUNNER (HSAMAG)
 case "hsamag":
 {
 	_unit addBackpack _baghsamag;
@@ -421,20 +422,20 @@ case "hsamag":
 // BACKPACK: ENGINEER (DEMO)
 case "eng":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR TOOLKIT)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addItemCargoGlobal ["ToolKit",1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addItemCargoGlobal ["ToolKit",1];
 		(unitBackpack _unit) addItemCargoGlobal [_satchel,2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -446,20 +447,20 @@ case "eng":
 // BACKPACK: ENGINEER (MINES)
 case "engm":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR TOOLKIT)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addItemCargoGlobal ["ToolKit",1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addItemCargoGlobal ["ToolKit",1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_ATmine,1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -471,13 +472,13 @@ case "engm":
 // BACKPACK: SUBMACHINEGUNNER (SMG)
 case "smg":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_smgmag,2];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,2];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -486,7 +487,7 @@ case "smg":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -500,7 +501,7 @@ case "smg":
 // BACKPACK: DIVER (DIV)
 case "div":
 {
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagmediumdiver;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -510,7 +511,7 @@ case "div":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmediumdiver;
 		clearMagazineCargoGlobal (unitBackpack _unit);

--- a/f/assignGear/f_assignGear_csat_b.sqf
+++ b/f/assignGear/f_assignGear_csat_b.sqf
@@ -122,7 +122,7 @@ case "aar":
 // BACKPACK: RIFLEMAN AT (RAT)
 case "rat":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR ROCKETS)
+	// NO BACKPACK
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -135,6 +135,7 @@ case "rat":
 		(unitBackpack _unit) addMagazineCargoGlobal [_grenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
+		(unitBackpack _unit) addMagazineCargoGlobal [_RATmag, 1];
 
 	};
 	// BACKPACK: HEAVY
@@ -142,7 +143,7 @@ case "rat":
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag, 4];
-		(unitBackpack _unit) addMagazineCargoGlobal [_RATmag, 1];
+		(unitBackpack _unit) addMagazineCargoGlobal [_RATmag, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_grenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
@@ -290,7 +291,7 @@ case "hmgag":
 // BACKPACK: MAT GUNNER (MATG)
 case "matg":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR ROCKETS)
+	// NO BACKPACK
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -328,7 +329,7 @@ case "matg":
 // BACKPACK: MAT ASSISTANT (MATAG)
 case "matag":
     {
-	// NO BACKPACK (STILL ADD SMALL FOR ROCKETS)
+	// NO BACKPACK
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -416,7 +417,7 @@ case "hsamag":
 // BACKPACK: ENGINEER (DEMO)
 case "eng":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR TOOLKIT)
+	// NO BACKPACK
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -441,7 +442,7 @@ case "eng":
 // BACKPACK: ENGINEER (MINES)
 case "engm":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR TOOLKIT)
+	// NO BACKPACK
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);

--- a/f/assignGear/f_assignGear_fia_b.sqf
+++ b/f/assignGear/f_assignGear_fia_b.sqf
@@ -5,7 +5,7 @@
 // BACKPACK: MEDIC
 case "m":
 {
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks <= 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -13,7 +13,7 @@ case "m":
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 4];
 		(unitBackpack _unit) addItemCargoGlobal [_firstaid, 4];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -26,7 +26,7 @@ case "m":
 // BACKPACK: GRENADIER (CO/DC/SL/FTL/G)
 case "g":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_glriflemag,2];
 		_unit addmagazines [_glmag,1];
@@ -34,7 +34,7 @@ case "g":
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,2];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -45,7 +45,7 @@ case "g":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -61,11 +61,11 @@ case "g":
 // BACKPACK: AR
 case "ar":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_ARmag_Tr,1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -75,7 +75,7 @@ case "ar":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -90,13 +90,13 @@ case "ar":
 // BACKPACK: AAR
 case "aar":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_ARmag,1];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -106,7 +106,7 @@ case "aar":
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_ARmag, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -122,23 +122,14 @@ case "aar":
 // BACKPACK: RIFLEMAN AT (RAT)
 case "rat":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR ROCKETS)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
-		clearMagazineCargoGlobal (unitBackpack _unit);
-		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag, 4];
-		(unitBackpack _unit) addMagazineCargoGlobal [_grenade, 2];
-		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
-		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
-	};
-	// BACKPACK: HEAVY
-	if (f_param_backpacks == 2) then {
-		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag, 4];
 		(unitBackpack _unit) addMagazineCargoGlobal [_grenade, 2];
@@ -146,18 +137,28 @@ case "rat":
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_RATmag, 1];
 	};
+	// LOADOUT: HEAVY
+	if (f_param_backpacks == 2) then {
+		_unit addBackpack _bagmedium;
+		clearMagazineCargoGlobal (unitBackpack _unit);
+		(unitBackpack _unit) addMagazineCargoGlobal [_riflemag, 4];
+		(unitBackpack _unit) addMagazineCargoGlobal [_grenade, 2];
+		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
+		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
+		(unitBackpack _unit) addMagazineCargoGlobal [_RATmag, 2];
+	};
 };
 
 // BACKPACK: RIFLEMAN (R)
 case "r":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_riflemag,2];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,2];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -166,7 +167,7 @@ case "r":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -181,13 +182,13 @@ case "r":
 // BACKPACK: CARABINEER (CAR)
 case "car":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_carbinemag,2];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,2];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -196,7 +197,7 @@ case "car":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -211,13 +212,13 @@ case "car":
 // BACKPACK: MMG GUNNER (MMG)
 case "mmg":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_MMGmag,1];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -226,7 +227,7 @@ case "mmg":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -238,13 +239,13 @@ case "mmg":
 	};
 };
 
-// BACKPACK: HEAVY MG GUNNER (HMGG)
+// LOADOUT: HEAVY MG GUNNER (HMGG)
 case "hmgg":
 {
 	_unit addBackpack _baghmgg;
 };
 
-// BACKPACK: HEAVY MG ASSISTANT GUNNER (HMGAG)
+// LOADOUT: HEAVY MG ASSISTANT GUNNER (HMGAG)
 case "hmgag":
 {
 	_unit addBackpack _baghmgag;
@@ -253,13 +254,13 @@ case "hmgag":
 // BACKPACK: MMG ASSISTANT GUNNER (MMGAG)
 case "mmgag":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_MMGmag,1];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -271,7 +272,7 @@ case "mmgag":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -288,7 +289,7 @@ case "mmgag":
 // BACKPACK: MAT GUNNER (MATG)
 case "matg":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR ROCKETS)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -299,7 +300,7 @@ case "matg":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -310,7 +311,7 @@ case "matg":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -326,7 +327,7 @@ case "matg":
 // BACKPACK: MAT ASSISTANT (MATAG)
 case "matag":
     {
-	// NO BACKPACK (STILL ADD SMALL FOR ROCKETS)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -336,7 +337,7 @@ case "matag":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -347,7 +348,7 @@ case "matag":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -359,13 +360,13 @@ case "matag":
 	};
 };
 
-// BACKPACK: HEAVY AT GUNNER (HATG)
+// LOADOUT: HEAVY AT GUNNER (HATG)
 case "hatg":
 {
 	_unit addBackpack _baghatg;
 };
 
-// BACKPACK: HEAVY AT ASSISTANT GUNNER (HATAG)
+// LOADOUT: HEAVY AT ASSISTANT GUNNER (HATAG)
 case "hatag":
 {
 	_unit addBackpack _baghatag;
@@ -399,13 +400,13 @@ case "msamag":
 	(unitBackpack _unit) addMagazineCargoGlobal [_SAMmag, 2];
 };
 
-// BACKPACK: HEAVY SAM GUNNER (HSAMG)
+// LOADOUT: HEAVY SAM GUNNER (HSAMG)
 case "hsamg":
 {
 	_unit addBackpack _baghsamg;
 };
 
-// BACKPACK: HEAVY SAM ASSISTANT GUNNER (HSAMAG)
+// LOADOUT: HEAVY SAM ASSISTANT GUNNER (HSAMAG)
 case "hsamag":
 {
 	_unit addBackpack _baghsamag;
@@ -414,20 +415,20 @@ case "hsamag":
 // BACKPACK: ENGINEER (DEMO)
 case "eng":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR TOOLKIT)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addItemCargoGlobal ["ToolKit",1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addItemCargoGlobal ["ToolKit",1];
 		(unitBackpack _unit) addItemCargoGlobal [_satchel,2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -439,20 +440,20 @@ case "eng":
 // BACKPACK: ENGINEER (MINES)
 case "engm":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR TOOLKIT)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addItemCargoGlobal ["ToolKit",1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addItemCargoGlobal ["ToolKit",1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_ATmine,1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -464,13 +465,13 @@ case "engm":
 // BACKPACK: SUBMACHINEGUNNER (SMG)
 case "smg":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_smgmag,2];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,2];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -479,7 +480,7 @@ case "smg":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -493,7 +494,7 @@ case "smg":
 // BACKPACK: DIVER (DIV)
 case "div":
 {
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagmediumdiver;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -503,7 +504,7 @@ case "div":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmediumdiver;
 		clearMagazineCargoGlobal (unitBackpack _unit);

--- a/f/assignGear/f_assignGear_nato_b.sqf
+++ b/f/assignGear/f_assignGear_nato_b.sqf
@@ -5,7 +5,7 @@
 // BACKPACK: MEDIC
 case "m":
 {
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks <= 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -13,7 +13,7 @@ case "m":
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 4];
 		(unitBackpack _unit) addItemCargoGlobal [_firstaid, 4];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -26,7 +26,7 @@ case "m":
 // BACKPACK: GRENADIER (CO/DC/SL/FTL/G)
 case "g":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_glriflemag,2];
 		_unit addmagazines [_glmag,1];
@@ -34,7 +34,7 @@ case "g":
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -45,7 +45,7 @@ case "g":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -61,11 +61,11 @@ case "g":
 // BACKPACK: AR
 case "ar":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_ARmag_Tr,2];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -75,7 +75,7 @@ case "ar":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -89,14 +89,14 @@ case "ar":
 // BACKPACK: AAR
 case "aar":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_riflemag,2];
 		_unit addmagazines [_ARmag,2];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,2];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -106,7 +106,7 @@ case "aar":
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_ARmag, 4];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -121,12 +121,12 @@ case "aar":
 // BACKPACK: RIFLEMAN AT (RAT)
 case "rat":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR ROCKETS)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -134,9 +134,8 @@ case "rat":
 		(unitBackpack _unit) addMagazineCargoGlobal [_grenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
-
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -151,13 +150,13 @@ case "rat":
 // BACKPACK: RIFLEMAN (R)
 case "r":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_riflemag,2];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,2];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -166,7 +165,7 @@ case "r":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -181,13 +180,13 @@ case "r":
 // BACKPACK: CARABINEER (CAR)
 case "car":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_carbinemag,2];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,2];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -196,7 +195,7 @@ case "car":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -211,13 +210,13 @@ case "car":
 // BACKPACK: MMG GUNNER (MMG)
 case "mmg":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_MMGmag,1];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -226,7 +225,7 @@ case "mmg":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -241,13 +240,13 @@ case "mmg":
 // BACKPACK: MMG ASSISTANT GUNNER (MMGAG)
 case "mmgag":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_MMGmag,1];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -259,7 +258,7 @@ case "mmgag":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -273,13 +272,13 @@ case "mmgag":
 	};
 };
 
-// BACKPACK: HEAVY MG GUNNER (HMGG)
+// LOADOUT: HEAVY MG GUNNER (HMGG)
 case "hmgg":
 {
 	_unit addBackpack _baghmgg;
 };
 
-// BACKPACK: HEAVY MG ASSISTANT GUNNER (HMGAG)
+// LOADOUT: HEAVY MG ASSISTANT GUNNER (HMGAG)
 case "hmgag":
 {
 	_unit addBackpack _baghmgag;
@@ -288,7 +287,7 @@ case "hmgag":
 // BACKPACK: MAT GUNNER (MATG)
 case "matg":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR ROCKETS)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -299,7 +298,7 @@ case "matg":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -310,7 +309,7 @@ case "matg":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -326,7 +325,7 @@ case "matg":
 // BACKPACK: MAT ASSISTANT (MATAG)
 case "matag":
     {
-	// NO BACKPACK (STILL ADD SMALL FOR ROCKETS)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -336,7 +335,7 @@ case "matag":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -347,7 +346,7 @@ case "matag":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -359,13 +358,13 @@ case "matag":
 	};
 };
 
-// BACKPACK: HEAVY AT GUNNER (HATG)
+// LOADOUT: HEAVY AT GUNNER (HATG)
 case "hatg":
 {
 	_unit addBackpack _baghatg;
 };
 
-// BACKPACK: HEAVY AT ASSISTANT GUNNER (HATAG)
+// LOADOUT: HEAVY AT ASSISTANT GUNNER (HATAG)
 case "hatag":
 {
 	_unit addBackpack _baghatag;
@@ -399,13 +398,13 @@ case "msamag":
 	(unitBackpack _unit) addMagazineCargoGlobal [_SAMmag, 2];
 };
 
-// BACKPACK: HEAVY SAM GUNNER (HSAMG)
+// LOADOUT: HEAVY SAM GUNNER (HSAMG)
 case "hsamg":
 {
 	_unit addBackpack _baghsamg;
 };
 
-// BACKPACK: HEAVY SAM ASSISTANT GUNNER (HSAMAG)
+// LOADOUT: HEAVY SAM ASSISTANT GUNNER (HSAMAG)
 case "hsamag":
 {
 	_unit addBackpack _baghsamag;
@@ -414,20 +413,20 @@ case "hsamag":
 // BACKPACK: ENGINEER (DEMO)
 case "eng":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR TOOLKIT)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addItemCargoGlobal ["ToolKit",1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addItemCargoGlobal ["ToolKit",1];
 		(unitBackpack _unit) addItemCargoGlobal [_satchel,2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -439,20 +438,20 @@ case "eng":
 // BACKPACK: ENGINEER (MINES)
 case "engm":
 {
-	// NO BACKPACK (STILL ADD SMALL FOR TOOLKIT)
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addItemCargoGlobal ["ToolKit",1];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 		(unitBackpack _unit) addItemCargoGlobal ["ToolKit",1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_ATmine,1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _baglarge;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -464,13 +463,13 @@ case "engm":
 // BACKPACK: SUBMACHINEGUNNER (SMG)
 case "smg":
 {
-	// NO BACKPACK
+	// LOADOUT: LIGHT
 	if (f_param_backpacks == 0) then {
 		_unit addmagazines [_smgmag,2];
 		_unit addmagazines [_grenade,1];_unit addmagazines [_mgrenade,1];
 		_unit addmagazines [_smokegrenade,2];
 	};
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagsmall;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -479,7 +478,7 @@ case "smg":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 2];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 2];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -493,7 +492,7 @@ case "smg":
 // BACKPACK: DIVER (DIV)
 case "div":
 {
-	// BACKPACK: LIGHT
+	// LOADOUT: MEDIUM
 	if (f_param_backpacks == 1) then {
 		_unit addBackpack _bagmediumdiver;
 		clearMagazineCargoGlobal (unitBackpack _unit);
@@ -503,7 +502,7 @@ case "div":
 		(unitBackpack _unit) addMagazineCargoGlobal [_mgrenade, 1];
 		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 1];
 	};
-	// BACKPACK: HEAVY
+	// LOADOUT: HEAVY
 	if (f_param_backpacks == 2) then {
 		_unit addBackpack _bagmediumdiver;
 		clearMagazineCargoGlobal (unitBackpack _unit);


### PR DESCRIPTION
- All RPG-32 RATs (AAF, FIA, CSAT) now carry one additional RPG-32 on "medium" and "heavy" loadouts for a total of 2/3.
- Fixed comments in assignGear_backpack files which were still referring to the old "backpack" parameter.
