### PR TITLE
F3 Nametag Fix for driver position

### DIFF
--- a/f/nametag/f_nametags.sqf
+++ b/f/nametag/f_nametags.sqf
@@ -19,6 +19,7 @@ f_height_standing_Nametags = 2;
 f_height_crouch_Nametags = 1.5;
 f_height_prone_Nametags = 0.9;
 f_vheight_Nametags = 0; // The height of the name tags for units in vehicles (0 = hovering over vehicle)
+F_SHADOW_NAMETAGS = 2; // The shadow for the name tags (0 - 2)
 
 f_color_Nametags =  [1,1,1,0.9]; // The color for infantry and units in vehicle cargo (in [red,green, blue, opacity])
 f_color2_Nametags = [0.5,0.1,0.2,0.9]; // The color for units in driver, gunner and other vehicle positions positions

--- a/f/nametag/fn_drawNametag.sqf
+++ b/f/nametag/fn_drawNametag.sqf
@@ -29,14 +29,14 @@ if (_suffix != "") then {_color = F_COLOR2_NAMETAGS};						 // Mounted units
 if(_x in units player) then { _color = f_groupColor_Nametags }; // Units of same group
 
 if (F_SHOWGROUP_NAMETAGS) then {_str = format ["%1 ",groupID (group _u)] + _str};
-	drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) + _height], 0, 0, 0, _str, 0,F_SIZE_NAMETAGS, F_FONT_NAMETAGS];
+	drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,F_SIZE_NAMETAGS, F_FONT_NAMETAGS];
 
 if (F_SHOWDISTANCE_NAMETAGS) then {
 	_str = format ["%1 m",round (_pos distance player)];
-	drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) - 0.15 + _height], 0, 0, 0, _str, 0,F_SIZE_NAMETAGS - 0.15, F_FONT_NAMETAGS];
+	drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) - 0.15 + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,F_SIZE_NAMETAGS - 0.15, F_FONT_NAMETAGS];
 };
 
 if (F_SHOWVEHICLE_NAMETAGS && !(typeOf (vehicle _u) isKindof "Man") && (assignedVehicleRole _u select 0 != "Cargo")) then {
 	_str = format ["%1",getText (configFile >> "CfgVehicles" >> (typeOf _veh) >> "displayname")];
-  drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) - 0.25 + _height], 0, 0, 0, _str, 0,F_SIZE_NAMETAGS - 0.15, F_FONT_NAMETAGS];
+  drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) - 0.25 + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,F_SIZE_NAMETAGS - 0.15, F_FONT_NAMETAGS];
 };


### PR DESCRIPTION
Fixes #447 
Adds new variable F_shadow_nametags at default value 2 to better highlight the name-tag. Can add screenshot if wanted.
