### PR TITLE
[assignGear] Re-added removal of assigned items.

### DIFF
--- a/f/assignGear/f_assignGear_aaf.sqf
+++ b/f/assignGear/f_assignGear_aaf.sqf
@@ -282,6 +282,7 @@ if (_isMan) then {
 	removeBackpack _unit;
 	removeAllWeapons _unit;
 	removeAllItemsWithMagazines _unit;
+	removeAllAssignedItems _unit;
 
 	// ====================================================================================
 

--- a/f/assignGear/f_assignGear_csat.sqf
+++ b/f/assignGear/f_assignGear_csat.sqf
@@ -288,6 +288,7 @@ if (_isMan) then {
 	removeBackpack _unit;
 	removeAllWeapons _unit;
 	removeAllItemsWithMagazines _unit;
+	removeAllAssignedItems _unit;
 
 	// ====================================================================================
 

--- a/f/assignGear/f_assignGear_fia.sqf
+++ b/f/assignGear/f_assignGear_fia.sqf
@@ -287,6 +287,7 @@ if (_isMan) then {
 	removeBackpack _unit;
 	removeAllWeapons _unit;
 	removeAllItemsWithMagazines _unit;
+	removeAllAssignedItems _unit;
 
 	// ====================================================================================
 

--- a/f/assignGear/f_assignGear_nato.sqf
+++ b/f/assignGear/f_assignGear_nato.sqf
@@ -281,6 +281,7 @@ if (_isMan) then {
 	removeBackpack _unit;
 	removeAllWeapons _unit;
 	removeAllItemsWithMagazines _unit;
+	removeAllAssignedItems _unit;
 
 	// ====================================================================================
 


### PR DESCRIPTION
- Adds 'removeAllAssignedItems' command for all factions.

I noticed that removing NVG's per the suggested method of commenting the linkItem wasn't working and had a community member have the same issue.
