### PR TITLE
New: F3 assignGear AI component

### DIFF
--- a/f/assignGear/f_assignGear_AI.sqf
+++ b/f/assignGear/f_assignGear_AI.sqf
@@ -9,9 +9,16 @@ if (isServer) exitWith {};
 
 // ====================================================================================
 
+// WAIT FOR COMMON VARIABLES
+// Make sure the common F3 variables are known
+
+waitUntil {scriptDone f_script_setLocalVars};
+
+// ====================================================================================
+
 // DECLARE PRIVATE VARIABLES
 
-private ["_unit","_faction","_unitFactions","_unitClasses"];
+private ["_units","_unit","_faction","_unitFactions","_unitClasses"];
 
 // ====================================================================================
 
@@ -57,6 +64,9 @@ _unitClasses = [
 
 // ====================================================================================
 
+// Interpret parameters
+_units = _this;
+
 // LOOP THROUGH AI UNITS AND ASSIGN GEAR
 
 {
@@ -87,4 +97,4 @@ _unitClasses = [
 				_x setvariable ["f_var_assignGear_done", true,true];
 			};
 	};
-} foreach allUnits;
+} foreach _units;

--- a/f/assignGear/f_assignGear_AI.sqf
+++ b/f/assignGear/f_assignGear_AI.sqf
@@ -1,0 +1,90 @@
+// F3 - Assign Gear Script - AI
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+// ====================================================================================
+
+// SERVER CHECK
+// Make sure that the script is only run on the server
+
+if (isServer) exitWith {};
+
+// ====================================================================================
+
+// DECLARE PRIVATE VARIABLES
+
+private ["_unit","_faction","_unitFactions","_unitClasses"];
+
+// ====================================================================================
+
+// SETUP CUSTOM VARIABLES
+
+// The factions of all units which should be affected
+_unitFactions = ["blu_f", "opf_f", "ind_f","blu_g_f","opf_g_f","ind_g_f"];
+
+// The unit classes and their corresponding F3 Assign Gear Component type
+_unitClasses = [
+
+	["_officer_"	,	"co"	],
+	["_colonel_"	,	"co"	],
+	["_sl_"			,	"dc"	],
+	["_tl_"			,	"ftl"	],
+	["_lite_"		,	"car"	],
+	["_ar_"			,	"ar"	],
+	["_aar_"		,	"aar"	],
+	["_a_"			,	"aar"	],
+	["_lat_"		,	"rat"	],
+	["_medic_"		,	"m"		],
+	["_gl_"			,	"gren"	],
+	["_exp_"		,	"eng"	],
+	["_engineer_"	,	"engm"	],
+	["_mg_"			,	"mgg"	],
+	["_amg_"		,	"mmgag"	],
+	["_at_"			,	"matg"	],
+	["_aat_"		,	"matag"	],
+	["_aa_"			,	"msamg"	],
+	["_aaa_"		,	"msamag"],
+	["_uav_"		,	"uav"	],
+	["_m_"			,	"sn"	],
+	["_sniper_"		,	"sn"	],
+	["_spotter_"	,	"sp"	],
+	["_diver_"		,	"div"	],
+	["_repair_"		,	"vd"	],
+	["_crew_"		,	"vd"	],
+	["_helipilot_"	,	"pp"	],
+	["_helicrew_"	,	"pc"	],
+	["_pilot_"		,	"pp"	]
+
+];
+
+// ====================================================================================
+
+// LOOP THROUGH AI UNITS AND ASSIGN GEAR
+
+{
+
+	sleep 0.1;
+	_unit = _x;
+
+	// Check if the unit was already touched by the F3 Assign Gear Component
+	if (!(_unit getvariable ["f_var_assignGear_done", false]) && {_unit isKindOf "Man"}) then {
+
+
+			_faction = toLower (faction _unit);
+			// If the unit's faction is allowed, proceed
+			if (_faction in _unitFactions) then {
+				{
+					// If the unit's classname corresponds to a class in the array, set it's gear accordingly
+					if [toLower (_x select 0),toLower (typeOf _unit)] call BIS_fnc_inString exitWith {
+						[[_unitClasses select 1, _unit], "f_fnc_assignGear", _unit] call BIS_fnc_MP;
+					};
+
+					// Otherwise set the default rifleman equipment
+					[["r", _unit], "f_fnc_assignGear", _unit] call BIS_fnc_MP;
+
+				} forEach _unitClasses;
+
+			} else {
+				// If the faction is not allowed, set the assignGear variable to true to ignore the unit from now on
+				_x setvariable ["f_var_assignGear_done", true,true];
+			};
+	};
+} foreach allUnits;

--- a/init.sqf
+++ b/init.sqf
@@ -130,7 +130,7 @@ if(isServer) then {
 // F3 - Assign Gear AI
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 
-[] execVM "f\assignGear\f_assignGear_AI.sqf";
+// [] execVM "f\assignGear\f_assignGear_AI.sqf";
 
 // ====================================================================================
 

--- a/init.sqf
+++ b/init.sqf
@@ -124,6 +124,14 @@ if(isServer) then {
 // [] execVM "f\setAISKill\f_setAISkill.sqf";
 // f_var_civAI = independent; // Optional: The civilian AI will use this side's settings
 
+
+// ====================================================================================
+
+// F3 - Assign Gear AI
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+
+// f_var_men execVM "f\assignGear\f_assignGear_AI.sqf";
+
 // ====================================================================================
 
 // F3 - Name Tags

--- a/init.sqf
+++ b/init.sqf
@@ -130,7 +130,7 @@ if(isServer) then {
 // F3 - Assign Gear AI
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 
-// f_var_men execVM "f\assignGear\f_assignGear_AI.sqf";
+[] execVM "f\assignGear\f_assignGear_AI.sqf";
 
 // ====================================================================================
 


### PR DESCRIPTION
As per #515

* Automatically equips AI infantry with F3 gear, based on their classname
* Runs only after mission start and with short sleep between units to avoid heavy performance impact (could still be noticeable in missions with hundreds of AI)
* Class -> F3 gear type assignment via paired array in scriptfile
* Can be passed an array of units to process, by default processes all AI present (excl. playableUnits)
* To ignore AI set variable ["f_var_assignGear_done", false]; in unit init
* Calling assignGear via unit init always has precedence over assignGear AI script
* Thanks to PabstMirror for the idea and his work which this is based on