### PR TITLE
F3 Nametags improvements

### DIFF
--- a/f/nametag/f_nametags.sqf
+++ b/f/nametag/f_nametags.sqf
@@ -14,7 +14,8 @@ if (!isDedicated && (isNull player)) then
 // SET GLOBAL VARIABLES
 
 // MODIFYABLE
-f_size_Nametags = 0.04; // The size the names are displayed in
+f_dist_Nametags = 15;	// Distance for the nametags to be displayed in
+f_size_Nametags = 0.03; // The size the names are displayed in
 f_height_standing_Nametags = 2;
 f_height_crouch_Nametags = 1.5;
 f_height_prone_Nametags = 0.9;
@@ -28,9 +29,9 @@ f_groupColor_Nametags = [0,1,0.7,0.9]; // The color for units of the same group
 F_FONT_NAMETAGS = "EtelkaMonospaceProBold"; // Font for the names
 F_KEY_NAMETAGS =  "TeamSwitch"; // The action key that will be used to toggle the name tags. See possible keys here: http://community.bistudio.com/wiki/Category:Key_Actions
 
-// SCRIPTSIDE
-F_DIST_NAMETAGS = _this select 0;
+f_cursortarget_nametags = true; // Toggle between showing only units under cursor or 360 radius
 
+// SCRIPTSIDE
 if (isNil "f_showGroup_Nametags") then {f_showGroup_Nametags = false};
 if (isNil "f_showDistance_Nametags") then {f_showDistance_Nametags = false};
 if (isNil "f_showVehicle_Nametags") then {f_showVehicle_Nametags = false};
@@ -38,7 +39,7 @@ if (isNil "f_showVehicle_Nametags") then {f_showVehicle_Nametags = false};
 F_DRAW_NAMETAGS = false;
 F_ACTIONKEY_NAMETAGS = (actionKeys F_KEY_NAMETAGS) select 0;
 F_KEYNAME_NAMETAGS = actionKeysNames F_KEY_NAMETAGS;
-if (isNil "F_ACTIONKEY_NAMETAGS") then {F_ACTIONKEY_NAMETAGS = 20; F_KEYNAME_NAMETAGS = 'T';}; // If the user has not bound 'TeamSwitch' to a key we default to 'T' to toggle the tags
+if (isNil "F_ACTIONKEY_NAMETAGS") then {F_ACTIONKEY_NAMETAGS = 20; F_KEYNAME_NAMETAGS = 'U';}; // If the user has not bound 'TeamSwitch' to a key we default to 'U' to toggle the tags
 
 F_KEYUP_NAMETAG = {
 	_key = _this select 1;
@@ -67,42 +68,33 @@ F_KEYDOWN_NAMETAG = {
 // A section is added to the player's briefing to inform them about name tags being available.
 
 [] spawn {
-waitUntil {scriptDone f_script_briefing};
+	waitUntil {scriptDone f_script_briefing};
 
-_bstr = format ["<br/>Toggle nametags for friendly units by pressing %1. This displays nametags for units within %3 m.<br/><br/>
+	//TODO add color section
+	_bstr = format ["<br/>Toggle nametags for friendly units by pressing %1. This displays nametags for units within %3 m.
+	",F_KEYNAME_NAMETAGS, F_KEY_NAMETAGS,F_DIST_NAMETAGS];
 
-If you do not have an key bound for %2 this will be 'T' by default. To bind the toggle to a different key bind your %2 key and click
-<execute expression=""
-F_ACTIONKEY_NAMETAGS = (actionKeys F_KEY_NAMETAGS) select 0;
-F_KEYNAME_NAMETAGS = actionKeysNames F_KEY_NAMETAGS;
-if (isNil 'F_ACTIONKEY_NAMETAGS') then {F_ACTIONKEY_NAMETAGS = 20; F_KEYNAME_NAMETAGS = 'T';};
-hintsilent 'Team switch key rebound!';
-"">here</execute>.
-",F_KEYNAME_NAMETAGS, F_KEY_NAMETAGS,F_DIST_NAMETAGS];
+	_bstr = _bstr + "<br/><br/>DISPLAY RADIUS<br/>Nametags can be displayed for only the targeted unit or in a 360° radius. To toggle this feature <execute expression=""
+		if (f_cursortarget_nametags) then {hintsilent 'Full radius display activated!';f_cursortarget_nametags= false} else {f_cursortarget_nametags = true;hintsilent 'Cursor display activated!'};""
+		>click here</execute>.";
 
-if (F_SHOWGROUP_NAMETAGS) then {
-_bstr = _bstr + "<br/><br/>GROUP NAMES<br/>Nametags display the unit's group name. To toggle this feature click <execute expression=""
-if (F_SHOWGROUP_NAMETAGS) then {hintsilent 'Group display deactivated!';F_SHOWGROUP_NAMETAGS= false} else {F_SHOWGROUP_NAMETAGS = true;hintsilent 'Group display activated!'};""
->here</execute>."
-};
+	_bstr = _bstr + "<br/><br/>GROUP NAMES<br/>Nametags display the unit's group name. To toggle this feature <execute expression=""
+	if (F_SHOWGROUP_NAMETAGS) then {hintsilent 'Group display deactivated!';F_SHOWGROUP_NAMETAGS= false} else {F_SHOWGROUP_NAMETAGS = true;hintsilent 'Group display activated!'};""
+	>click here</execute>.";
 
-if (F_SHOWDISTANCE_NAMETAGS) then {
-_bstr = _bstr + "<br/><br/>DISTANCE<br/>Nametags display the unit's relative distance to you. To toggle this feature click <execute expression=""
-if (F_SHOWDISTANCE_NAMETAGS) then {hintsilent 'Distance display deactivated!';F_SHOWDISTANCE_NAMETAGS= false} else {F_SHOWDISTANCE_NAMETAGS = true;hintsilent 'Distance display activated!'};""
->here</execute>."
-};
+	_bstr = _bstr + "<br/><br/>DISTANCE<br/>Nametags display the unit's relative distance to you. To toggle this feature <execute expression=""
+	if (F_SHOWDISTANCE_NAMETAGS) then {hintsilent 'Distance display deactivated!';F_SHOWDISTANCE_NAMETAGS= false} else {F_SHOWDISTANCE_NAMETAGS = true;hintsilent 'Distance display activated!'};""
+	>click here</execute>.";
 
-if (F_SHOWVEHICLE_NAMETAGS) then {
-_bstr = _bstr + "<br/><br/>VEHICLE TYPES<br/>Nametags display the vehicle type of any mounted units. To toggle this feature click <execute expression=""
-if (F_SHOWVEHICLE_NAMETAGS) then {hintsilent 'Vehicle type display deactivated!';F_SHOWVEHICLE_NAMETAGS= false} else {F_SHOWVEHICLE_NAMETAGS = true;hintsilent 'Vehicle type display activated!'};""
->here</execute>."
-};
+	_bstr = _bstr + "<br/><br/>VEHICLE TYPES<br/>Nametags display the vehicle type of any mounted units. To toggle this feature <execute expression=""
+	if (F_SHOWVEHICLE_NAMETAGS) then {hintsilent 'Vehicle type display deactivated!';F_SHOWVEHICLE_NAMETAGS= false} else {F_SHOWVEHICLE_NAMETAGS = true;hintsilent 'Vehicle type display activated!'};""
+	>click here</execute>.";
 
-player createDiaryRecord ["Diary", ["NameTags",_bstr]];
+	player createDiaryRecord ["Diary", ["F3 NameTags",_bstr]];
 
-// NOTIFY PLAYER ABOUT NAMETAGS VIA HINT
-sleep 5;
-hintsilent format ["Press %1 to toggle name tags", F_KEYNAME_NAMETAGS ];
+	// NOTIFY PLAYER ABOUT NAMETAGS VIA HINT
+	sleep 5;
+	hintsilent format ["Press %1 to toggle name tags", F_KEYNAME_NAMETAGS];
 };
 
 // ====================================================================================
@@ -113,6 +105,8 @@ hintsilent format ["Press %1 to toggle name tags", F_KEYNAME_NAMETAGS ];
 sleep 0.1;
 
 waitUntil {!isNull (findDisplay 46)}; // Make sure the display we need is initialized
+
+F_DRAW_NAMETAGS = true; // Enable nametags from the start
 
 (findDisplay 46) displayAddEventHandler   ["keyup", "_this call F_KEYUP_NAMETAG"];
 (findDisplay 46) displayAddEventHandler   ["keydown", "_this call F_KEYDOWN_NAMETAG"];
@@ -128,19 +122,32 @@ addMissionEventHandler ["Draw3D", {
 	private ["_ents","_veh","_color","_inc","_suffix","_pos","_angle"];
 
 	// Collect all entities in the relevant distance
-	_ents = (position player) nearEntities [["CAManBase","LandVehicle","Helicopter","Plane","Ship_F"], F_DIST_NAMETAGS];
+
+	_ents =[];
+
+		if (f_cursortarget_nametags) then {
+			if ((player distance cursorTarget) <= F_DIST_NAMETAGS) then {_ents = [cursortarget]};
+		} else {
+			_ents = (position player) nearEntities [["CAManBase","LandVehicle","Helicopter","Plane","Ship_F"], F_DIST_NAMETAGS];
+		};
 
 		// Start looping through all entities
 		{
-			// Only display units of players side
-			if(side _x == side player && _x != player && !(player iskindof "VirtualMan_F")) then
+			// Filter entities
+			if (
+				// Only for the player's side
+				side _x == side player &&
+				// Only other players & no virtual units
+				{_x != player && !(player iskindof "VirtualMan_F")}
+				)
+			then
 			{
 
 				// If the entity is Infantry
-				if(typeof _x iskindof "Man") then
+				if((typeof _x) iskindof "Man") then
 				{
-						_pos = visiblePosition _x;
-						[_x,_pos] call f_fnc_drawNameTag;
+					_pos = visiblePosition _x;
+					[_x,_pos] call f_fnc_drawNameTag;
 				}
 
 				// Else (if it's a vehicle)
@@ -198,7 +205,9 @@ addMissionEventHandler ["Draw3D", {
 							}
 							else
 							{
-								[_x,_pos,_suffix] call f_fnc_drawNameTag;
+								if (group _x == group player) then {
+									[_x,_pos,_suffix] call f_fnc_drawNameTag;
+								};
 							};
 						}
 						else

--- a/f/nametag/f_nametags.sqf
+++ b/f/nametag/f_nametags.sqf
@@ -75,26 +75,31 @@ F_KEYDOWN_NAMETAG = {
 	waitUntil {scriptDone f_script_briefing};
 
 	//TODO add color section
-	_bstr = format ["<br/><font size='18'>F3 NAMETAGS</font><br/>Toggle nametags for friendly units by pressing %1. This displays nametags for units within %3 m.
-	",F_KEYNAME_NAMETAGS, F_KEY_NAMETAGS,F_DISTALL_NAMETAGS];
+	_bstr = format ["<br/><font size='18'>F3 NAMETAGS</font><br/>Toggle nametags for friendly units by pressing %1. This displays nametags for units within %3m of you and when aiming at units in %4m. Various features can be toggled below.
+	",F_KEYNAME_NAMETAGS, F_KEY_NAMETAGS,F_DISTALL_NAMETAGS,F_DISTCursor_NAMETAGS];
 
 	/*_bstr = _bstr + "<br/><br/><font size='18'>DISPLAY RADIUS</font><br/>Nametags can be displayed for only the targeted unit or in a 360° radius. To toggle this feature <execute expression=""
 		if (f_cursortarget_nametags) then [{hintsilent 'Full radius display activated!';f_cursortarget_nametags= false},{f_cursortarget_nametags = true;hintsilent 'Cursor display activated!'}];""
 		>click here</execute>.";*/
 
-	_bstr = _bstr + "<br/><br/><font size='18'>GROUP NAMES</font><br/>Nametags can show group name's next to friendly units who are not in your own group. To toggle this feature <execute expression=""
+	_bstr = _bstr + "<br/><br/><execute expression=""
 	if (F_SHOWGROUP_NAMETAGS) then [{hintsilent 'Group display deactivated!';F_SHOWGROUP_NAMETAGS= false},{F_SHOWGROUP_NAMETAGS = true;hintsilent 'Group display activated!'}];""
-	>click here</execute>.";
+	>TOGGLE GROUP NAME DISPLAY</execute>.<br/> Shows group name next to a unit's name.";
 
-	_bstr = _bstr + "<br/><br/><font size='18'>DISTANCE</font><br/>Nametags can display the unit's relative distance to yourself. To toggle this feature <execute expression=""
+	_bstr = _bstr + "<br/><br/><execute expression=""
 	if (F_SHOWDISTANCE_NAMETAGS) then [{hintsilent 'Distance display deactivated!';F_SHOWDISTANCE_NAMETAGS= false},{F_SHOWDISTANCE_NAMETAGS = true;hintsilent 'Distance display activated!'}];""
-	>click here</execute>.";
+	>TOGGLE DISTANCE DISPLAY</execute>.<br/> Displays distance to other units under the name tag.";
 
-	_bstr = _bstr + "<br/><br/><font size='18'>VEHICLE TYPES</font><br/>Nametags can display the vehicle type under the driver's name. To toggle this feature <execute expression=""
+	_bstr = _bstr + "<br/><br/><execute expression=""
 	if (F_SHOWVEHICLE_NAMETAGS) then [{hintsilent 'Vehicle type display deactivated!';F_SHOWVEHICLE_NAMETAGS= false},{F_SHOWVEHICLE_NAMETAGS = true;hintsilent 'Vehicle type display activated!'}];""
-	>click here</execute>.";
+	>TOGGLE VEHICLE TYPE DISPLAY</execute>.<br/> Displays the vehicle type under the driver's name.";
 
-	player createDiaryRecord ["Diary", ["F3 NameTags",_bstr]];
+	_bstr = _bstr + "<br/><br/><font size='18'>COLORS</font><br/>
+	<font color='#FFFFFF'>Friendly</font><br/>
+	<font color='#7FFFD4'>Fireteam</font><br/>
+	<font color='#DC143C'>Vehicle Crew</font>";
+
+	player createDiaryRecord ["Diary", ["F3 NameTags (Options)",_bstr]];
 
 	// NOTIFY PLAYER ABOUT NAMETAGS VIA HINT
 	sleep 5;
@@ -129,7 +134,7 @@ addMissionEventHandler ["Draw3D", {
 
 	_ents = (position player) nearEntities [["CAManBase","LandVehicle","Helicopter","Plane","Ship_F"], f_distAll_Nametags];
 
-	if (!(cursorTarget in _ents) && ((player distance cursorTarget) <= f_distCursor_Nametags)) then {_ents append [cursorTarget]};
+	if (!(cursorTarget in _ents) && {((player distance cursorTarget) <= f_distCursor_Nametags) && player knowsAbout cursorTarget >= 1.5}) then {_ents append [cursorTarget]};
 
 		/*if (f_cursortarget_nametags) then {
 			if ((player distance cursorTarget) <= F_DIST_NAMETAGS) then {_ents = [cursortarget]};

--- a/f/nametag/f_nametags.sqf
+++ b/f/nametag/f_nametags.sqf
@@ -22,7 +22,8 @@ f_showVehicle_Nametags = false;  // Show type of vehicle under driver's name
 f_cursortarget_Nametags = false;  // True shows only name for units aimed, false displays tags for all unit in radius
 
 // Other values
-f_dist_Nametags = 15;	// Distance for the nametags to be displayed in
+f_distCursor_Nametags = 22;		// Distance to display name tag for unit under cursor
+f_distAll_Nametags = 10;		// Distance to display name tags for all units around
 F_KEY_NAMETAGS =  "TeamSwitch"; // The action key to toggle the name tags. See possible keys here: http://community.bistudio.com/wiki/Category:Key_Actions
 
 // Display values
@@ -75,11 +76,11 @@ F_KEYDOWN_NAMETAG = {
 
 	//TODO add color section
 	_bstr = format ["<br/><font size='18'>F3 NAMETAGS</font><br/>Toggle nametags for friendly units by pressing %1. This displays nametags for units within %3 m.
-	",F_KEYNAME_NAMETAGS, F_KEY_NAMETAGS,F_DIST_NAMETAGS];
+	",F_KEYNAME_NAMETAGS, F_KEY_NAMETAGS,F_DISTALL_NAMETAGS];
 
-	_bstr = _bstr + "<br/><br/><font size='18'>DISPLAY RADIUS</font><br/>Nametags can be displayed for only the targeted unit or in a 360° radius. To toggle this feature <execute expression=""
+	/*_bstr = _bstr + "<br/><br/><font size='18'>DISPLAY RADIUS</font><br/>Nametags can be displayed for only the targeted unit or in a 360° radius. To toggle this feature <execute expression=""
 		if (f_cursortarget_nametags) then [{hintsilent 'Full radius display activated!';f_cursortarget_nametags= false},{f_cursortarget_nametags = true;hintsilent 'Cursor display activated!'}];""
-		>click here</execute>.";
+		>click here</execute>.";*/
 
 	_bstr = _bstr + "<br/><br/><font size='18'>GROUP NAMES</font><br/>Nametags can show group name's next to friendly units who are not in your own group. To toggle this feature <execute expression=""
 	if (F_SHOWGROUP_NAMETAGS) then [{hintsilent 'Group display deactivated!';F_SHOWGROUP_NAMETAGS= false},{F_SHOWGROUP_NAMETAGS = true;hintsilent 'Group display activated!'}];""
@@ -126,13 +127,15 @@ addMissionEventHandler ["Draw3D", {
 
 	// Collect all entities in the relevant distance
 
-	_ents =[];
+	_ents = (position player) nearEntities [["CAManBase","LandVehicle","Helicopter","Plane","Ship_F"], f_distAll_Nametags];
 
-		if (f_cursortarget_nametags) then {
+	if (!(cursorTarget in _ents) && ((player distance cursorTarget) <= f_distCursor_Nametags)) then {_ents append [cursorTarget]};
+
+		/*if (f_cursortarget_nametags) then {
 			if ((player distance cursorTarget) <= F_DIST_NAMETAGS) then {_ents = [cursortarget]};
 		} else {
-			_ents = (position player) nearEntities [["CAManBase","LandVehicle","Helicopter","Plane","Ship_F"], F_DIST_NAMETAGS];
-		};
+			_ents = (position player) nearEntities [["CAManBase","LandVehicle","Helicopter","Plane","Ship_F"], f_distAll_Nametags];
+		};*/
 
 		// Start looping through all entities
 		{

--- a/f/nametag/f_nametags.sqf
+++ b/f/nametag/f_nametags.sqf
@@ -192,7 +192,7 @@ addMissionEventHandler ["Draw3D", {
 						_pos = visiblePosition _x;
 
 						// Only display tags for non-driver crew and cargo if player is up close
-						if (driver _veh == _x || effectiveCommander _veh == _x || group _x == group player || _pos distance player <= f_distAll_Nametags) then {
+						if (effectiveCommander _veh == _x || group _x == group player || _pos distance player <= f_distAll_Nametags) then {
 
 							// If the unit is the driver, calculate the available and taken seats
 							if (effectiveCommander _veh == _x) then {

--- a/f/nametag/f_nametags.sqf
+++ b/f/nametag/f_nametags.sqf
@@ -16,25 +16,26 @@ if (!isDedicated && (isNull player)) then
 // MODIFYABLE
 
 // Default values (can be modified by players in the briefing entry)
+// Comment any of these to deactivate the feature entirely
 f_showGroup_Nametags = true;	 // Show unit's group next to unit name (except for player's own group)
 f_showDistance_Nametags = false; // Show distance to unit under name
 f_showVehicle_Nametags = false;  // Show type of vehicle under driver's name
-f_cursortarget_Nametags = false;  // True shows only name for units aimed, false displays tags for all unit in radius
+f_showCursorOnly_Nametags = false; // Show only units under cursor target (disable 360° view)
 
 // Other values
-f_distCursor_Nametags = 22;		// Distance to display name tag for unit under cursor
+f_distCursor_Nametags = 25;		// Distance to display name tag for unit under cursor
 f_distAll_Nametags = 10;		// Distance to display name tags for all units around
 F_KEY_NAMETAGS =  "TeamSwitch"; // The action key to toggle the name tags. See possible keys here: http://community.bistudio.com/wiki/Category:Key_Actions
 
 // Display values
-f_size_Nametags = 0.032; // The size the names are displayed in
+f_size_Nametags = 0.023; // The size the names are displayed in
 f_height_standing_Nametags = 2; // Height above standing infantry unit
 f_height_crouch_Nametags = 1.5; // Height above crouching infantry unit
 f_height_prone_Nametags = 0.9;  // Height above prone infantry unit
 f_vheight_Nametags = 0; // The height of the name tags for units in vehicles (0 = hovering over vehicle)
 F_SHADOW_NAMETAGS = 2; // The shadow for the name tags (0 - 2)
 f_color_Nametags =  [1,1,1,0.9]; // The color for infantry and units in vehicle cargo (in [red,green, blue, opacity])
-f_color2_Nametags = [0.5,0.1,0.2,0.9]; // The color for units in driver, gunner and other vehicle positions positions
+f_color2_Nametags = [1,0.1,0.2,0.9]; // The color for units in driver, gunner and other vehicle positions positions
 f_groupColor_Nametags = [0,1,0.7,0.9]; // The color for units of the same group
 F_FONT_NAMETAGS = "EtelkaMonospaceProBold"; // Font for the names
 
@@ -74,30 +75,35 @@ F_KEYDOWN_NAMETAG = {
 [] spawn {
 	waitUntil {scriptDone f_script_briefing};
 
-	//TODO add color section
-	_bstr = format ["<br/><font size='18'>F3 NAMETAGS</font><br/>Toggle nametags for friendly units by pressing %1. This displays nametags for units within %3m of you and when aiming at units in %4m. Various features can be toggled below.
-	",F_KEYNAME_NAMETAGS, F_KEY_NAMETAGS,F_DISTALL_NAMETAGS,F_DISTCursor_NAMETAGS];
+	_bstr = format ["<font size='18'>F3 NAME TAGS</font><br/>Toggle name tags for friendly units by pressing %1.<br/><br/>
+Name tags are displayed when aiming at individual units up to %4m away, and constantly for all units within %3m.
+        ",F_KEYNAME_NAMETAGS, F_KEY_NAMETAGS,F_DISTALL_NAMETAGS,F_DISTCursor_NAMETAGS];
 
-	/*_bstr = _bstr + "<br/><br/><font size='18'>DISPLAY RADIUS</font><br/>Nametags can be displayed for only the targeted unit or in a 360° radius. To toggle this feature <execute expression=""
-		if (f_cursortarget_nametags) then [{hintsilent 'Full radius display activated!';f_cursortarget_nametags= false},{f_cursortarget_nametags = true;hintsilent 'Cursor display activated!'}];""
-		>click here</execute>.";*/
+        _bstr = _bstr + "<br/><br/><execute expression=""
+                if (f_showCursorOnly_Nametags) then [{hintsilent 'Constant tags activated!';f_showCursorOnly_Nametags= false},{f_showCursorOnly_Nametags = true;hintsilent 'Constant tags deactivated!'}];""
+                >TOGGLE CONSTANT TAGS</execute>.<br/> Constantly displays name tags for nearby units.";
 
-	_bstr = _bstr + "<br/><br/><execute expression=""
-	if (F_SHOWGROUP_NAMETAGS) then [{hintsilent 'Group display deactivated!';F_SHOWGROUP_NAMETAGS= false},{F_SHOWGROUP_NAMETAGS = true;hintsilent 'Group display activated!'}];""
-	>TOGGLE GROUP NAME DISPLAY</execute>.<br/> Shows group name next to a unit's name.";
+        if !(isNil "F_SHOWGROUP_NAMETAGS") then {
+                _bstr = _bstr + "<br/><br/><execute expression=""
+                if (F_SHOWGROUP_NAMETAGS) then [{hintsilent 'Group display deactivated!';F_SHOWGROUP_NAMETAGS= false},{F_SHOWGROUP_NAMETAGS = true;hintsilent 'Group display activated!'}];""
+                >TOGGLE GROUP NAME DISPLAY</execute>.<br/> Displays the group name next to a unit's name.";
+        };
 
-	_bstr = _bstr + "<br/><br/><execute expression=""
-	if (F_SHOWDISTANCE_NAMETAGS) then [{hintsilent 'Distance display deactivated!';F_SHOWDISTANCE_NAMETAGS= false},{F_SHOWDISTANCE_NAMETAGS = true;hintsilent 'Distance display activated!'}];""
-	>TOGGLE DISTANCE DISPLAY</execute>.<br/> Displays distance to other units under the name tag.";
+        if !(isNil "F_SHOWDISTANCE_NAMETAGS") then {
+                _bstr = _bstr + "<br/><br/><execute expression=""
+                if (F_SHOWDISTANCE_NAMETAGS) then [{hintsilent 'Distance display deactivated!';F_SHOWDISTANCE_NAMETAGS= false},{F_SHOWDISTANCE_NAMETAGS = true;hintsilent 'Distance display activated!'}];""
+                >TOGGLE DISTANCE DISPLAY</execute>.<br/> Displays distance to other units under each name tag.";
+        };
 
-	_bstr = _bstr + "<br/><br/><execute expression=""
-	if (F_SHOWVEHICLE_NAMETAGS) then [{hintsilent 'Vehicle type display deactivated!';F_SHOWVEHICLE_NAMETAGS= false},{F_SHOWVEHICLE_NAMETAGS = true;hintsilent 'Vehicle type display activated!'}];""
-	>TOGGLE VEHICLE TYPE DISPLAY</execute>.<br/> Displays the vehicle type under the driver's name.";
+        if !(isNil "f_showVehicle_Nametags") then {
+                _bstr = _bstr + "<br/><br/><execute expression=""
+                if (f_showVehicle_Nametags) then [{hintsilent 'Vehicle type display deactivated!';F_SHOWVEHICLE_NAMETAGS= false},{F_SHOWVEHICLE_NAMETAGS = true;hintsilent 'Vehicle type display activated!'}];"">TOGGLE VEHICLE TYPE DISPLAY</execute>.<br/> Displays the vehicle type under the driver's name.";
+        };
 
-	_bstr = _bstr + "<br/><br/><font size='18'>COLORS</font><br/>
-	<font color='#FFFFFF'>Friendly</font><br/>
-	<font color='#7FFFD4'>Fireteam</font><br/>
-	<font color='#DC143C'>Vehicle Crew</font>";
+    _bstr = _bstr + "<br/><br/><font size='18'>COLORS</font><br/>
+    <font color='#FFFFFF'>Friendly</font><br/>
+    <font color='#7FFFD4'>Fireteam</font><br/>
+    <font color='#FF143C'>Vehicle Crew</font>";
 
 	player createDiaryRecord ["Diary", ["F3 NameTags (Options)",_bstr]];
 
@@ -130,9 +136,12 @@ addMissionEventHandler ["Draw3D", {
 
 	private ["_ents","_veh","_color","_inc","_suffix","_pos","_angle"];
 
-	// Collect all entities in the relevant distance
+	_ents = [];
 
-	_ents = (position player) nearEntities [["CAManBase","LandVehicle","Helicopter","Plane","Ship_F"], f_distAll_Nametags];
+	// Unless disabled, collect all entities in the relevant distance
+	if !(f_showCursorOnly_Nametags) then {
+		_ents = (position player) nearEntities [["CAManBase","LandVehicle","Helicopter","Plane","Ship_F"], f_distAll_Nametags];
+	};
 
 	if (!(cursorTarget in _ents) && {((player distance cursorTarget) <= f_distCursor_Nametags) && player knowsAbout cursorTarget >= 1.5}) then {_ents append [cursorTarget]};
 
@@ -170,73 +179,53 @@ addMissionEventHandler ["Draw3D", {
 					_alternate = 0;
 
 					{
-
-						_suffix = "";
-
 						// Get the various crew slots
-						if(driver _veh == _x) then
-						{
-							_suffix = " - D";
-						};
-						if(gunner _veh == _x) then
-						{
-							_suffix = " - G";
-						};
-						if(commander _veh == _x) then
-						{
-							_suffix = " - C";
-						};
-						if(assignedVehicleRole _x select 0 == "Turret" && commander _veh != _x && gunner _veh != _x && driver _veh != _x) then
-						{
-							_suffix = " - G";
+						_suffix = switch (true) do {
+							case (driver _veh == _x):{" - D"};
+							case (commander _veh == _x);
+							case (effectiveCommander _veh == _x):{" - C"};
+							case (gunner _veh == _x);
+							case (assignedVehicleRole _x select 0 == "Turret" && commander _veh != _x && gunner _veh != _x && driver _veh != _x):{" - G"};
+							default {""};
 						};
 
 						_pos = visiblePosition _x;
 
-						// If the unit is a passenger or the driver
-						if (_pos distance (getPosVisual (driver _veh)) > 0.1 || driver _veh == _x) then
-						{
+						// Only display tags for non-driver crew and cargo if player is up close
+						if (driver _veh == _x || effectiveCommander _veh == _x || group _x == group player || _pos distance player <= f_distAll_Nametags) then {
 
-							// If it's the driver calculate the cargo slots
-							if(driver _veh == _x) then
-							{
+							// If the unit is the driver, calculate the available and taken seats
+							if (effectiveCommander _veh == _x) then {
 								// Workaround for http://feedback.arma3.com/view.php?id=21602
 								_maxSlots = getNumber(configfile >> "CfgVehicles" >> typeof _veh >> "transportSoldier") + (count allTurrets [_veh, true] - count allTurrets _veh);
 								_freeSlots = _veh emptyPositions "cargo";
 
 								if (_maxSlots > 0) then {
-
-								_suffix = _suffix + format [" (%1/%2)",(_maxSlots-_freeSlots),_maxSlots];
-
-								[_x,_pos,_suffix] call f_fnc_drawNameTag;
-
-								} else {
-									[_x,_pos,_suffix] call f_fnc_drawNameTag;
-								};
-							}
-							else
-							{
-								if (group _x == group player) then {
-									[_x,_pos,_suffix] call f_fnc_drawNameTag;
+									_suffix = _suffix + format [" (%1/%2)",(_maxSlots-_freeSlots),_maxSlots];
 								};
 							};
-						}
-						else
-						{
-							if(_x == gunner _veh) then
-							{
-								_pos = [_veh modeltoworld (_veh selectionPosition "gunnerview") select 0,_veh modeltoworld (_veh selectionPosition "gunnerview") select 1,(visiblePosition _x) select 2];
 
+							// If the unit is in a turret, a passenger or the driver
+							if (_pos distance (getPosVisual (driver _veh)) > 0.1 || driver _veh == _x) then
+							{
 								[_x,_pos,_suffix] call f_fnc_drawNameTag;
 							}
-							else
+							else // Gunners and all other slots
 							{
-								_angle = (getdir _veh)+180;
-								_pos = [((_pos select 0) + sin(_angle)*(0.6*_inc)) , (_pos select 1) + cos(_angle)*(0.6*_inc),_pos select 2 + F_VHEIGHT_NAMETAGS];
+								if(_x == gunner _veh) then
+								{
+									_pos = [_veh modeltoworld (_veh selectionPosition "gunnerview") select 0,_veh modeltoworld (_veh selectionPosition "gunnerview") select 1,(visiblePosition _x) select 2];
+								}
+								else
+								{
+									_angle = (getdir _veh)+180;
+									_pos = [((_pos select 0) + sin(_angle)*(0.6*_inc)) , (_pos select 1) + cos(_angle)*(0.6*_inc),_pos select 2 + F_VHEIGHT_NAMETAGS];
+									_inc = _inc + 1;
+								};
 
 								[_x,_pos,_suffix] call f_fnc_drawNameTag;
-								_inc = _inc + 1;
 							};
+
 						};
 
 					} foreach crew _veh;

--- a/f/nametag/f_nametags.sqf
+++ b/f/nametag/f_nametags.sqf
@@ -23,7 +23,7 @@ f_showVehicle_Nametags = false;  // Show type of vehicle under driver's name
 f_showCursorOnly_Nametags = false; // Show only units under cursor target (disable 360° view)
 
 // Other values
-f_distCursor_Nametags = 25;		// Distance to display name tag for unit under cursor
+f_distCursor_Nametags = 28;		// Distance to display name tag for unit under cursor
 f_distAll_Nametags = 10;		// Distance to display name tags for all units around
 F_KEY_NAMETAGS =  "TeamSwitch"; // The action key to toggle the name tags. See possible keys here: http://community.bistudio.com/wiki/Category:Key_Actions
 
@@ -181,8 +181,8 @@ addMissionEventHandler ["Draw3D", {
 					{
 						// Get the various crew slots
 						_suffix = switch (true) do {
-							case (driver _veh == _x && !(toLower (typeOf _veh) in ["helicopter","plane"])):{" - D"};
-							case (driver _veh == _x && (toLower (typeOf _veh) in ["helicopter","plane"])):{" - P"};
+							case (driver _veh == _x && !((_veh isKindOf "helicopter") || (_veh isKindOf "plane"))):{" - D"};
+							case (driver _veh == _x && ((_veh isKindOf "helicopter") || (_veh isKindOf "plane"))):{" - P"};
 							case (commander _veh == _x);
 							case (effectiveCommander _veh == _x):{" - CO"};
 							case (gunner _veh == _x):{" - G"};

--- a/f/nametag/f_nametags.sqf
+++ b/f/nametag/f_nametags.sqf
@@ -181,11 +181,12 @@ addMissionEventHandler ["Draw3D", {
 					{
 						// Get the various crew slots
 						_suffix = switch (true) do {
-							case (driver _veh == _x):{" - D"};
+							case (driver _veh == _x && !(toLower (typeOf _veh) in ["helicopter","plane"])):{" - D"};
+							case (driver _veh == _x && (toLower (typeOf _veh) in ["helicopter","plane"])):{" - P"};
 							case (commander _veh == _x);
-							case (effectiveCommander _veh == _x):{" - C"};
-							case (gunner _veh == _x);
-							case (assignedVehicleRole _x select 0 == "Turret" && commander _veh != _x && gunner _veh != _x && driver _veh != _x):{" - G"};
+							case (effectiveCommander _veh == _x):{" - CO"};
+							case (gunner _veh == _x):{" - G"};
+							case (assignedVehicleRole _x select 0 == "Turret" && commander _veh != _x && gunner _veh != _x && driver _veh != _x):{" - C"};
 							default {""};
 						};
 

--- a/f/nametag/f_nametags.sqf
+++ b/f/nametag/f_nametags.sqf
@@ -14,27 +14,30 @@ if (!isDedicated && (isNull player)) then
 // SET GLOBAL VARIABLES
 
 // MODIFYABLE
+
+// Default values (can be modified by players in the briefing entry)
+f_showGroup_Nametags = true;	 // Show unit's group next to unit name (except for player's own group)
+f_showDistance_Nametags = false; // Show distance to unit under name
+f_showVehicle_Nametags = false;  // Show type of vehicle under driver's name
+f_cursortarget_Nametags = false;  // True shows only name for units aimed, false displays tags for all unit in radius
+
+// Other values
 f_dist_Nametags = 15;	// Distance for the nametags to be displayed in
-f_size_Nametags = 0.03; // The size the names are displayed in
-f_height_standing_Nametags = 2;
-f_height_crouch_Nametags = 1.5;
-f_height_prone_Nametags = 0.9;
+F_KEY_NAMETAGS =  "TeamSwitch"; // The action key to toggle the name tags. See possible keys here: http://community.bistudio.com/wiki/Category:Key_Actions
+
+// Display values
+f_size_Nametags = 0.032; // The size the names are displayed in
+f_height_standing_Nametags = 2; // Height above standing infantry unit
+f_height_crouch_Nametags = 1.5; // Height above crouching infantry unit
+f_height_prone_Nametags = 0.9;  // Height above prone infantry unit
 f_vheight_Nametags = 0; // The height of the name tags for units in vehicles (0 = hovering over vehicle)
 F_SHADOW_NAMETAGS = 2; // The shadow for the name tags (0 - 2)
-
 f_color_Nametags =  [1,1,1,0.9]; // The color for infantry and units in vehicle cargo (in [red,green, blue, opacity])
 f_color2_Nametags = [0.5,0.1,0.2,0.9]; // The color for units in driver, gunner and other vehicle positions positions
 f_groupColor_Nametags = [0,1,0.7,0.9]; // The color for units of the same group
-
 F_FONT_NAMETAGS = "EtelkaMonospaceProBold"; // Font for the names
-F_KEY_NAMETAGS =  "TeamSwitch"; // The action key that will be used to toggle the name tags. See possible keys here: http://community.bistudio.com/wiki/Category:Key_Actions
-
-f_cursortarget_nametags = true; // Toggle between showing only units under cursor or 360 radius
 
 // SCRIPTSIDE
-if (isNil "f_showGroup_Nametags") then {f_showGroup_Nametags = false};
-if (isNil "f_showDistance_Nametags") then {f_showDistance_Nametags = false};
-if (isNil "f_showVehicle_Nametags") then {f_showVehicle_Nametags = false};
 
 F_DRAW_NAMETAGS = false;
 F_ACTIONKEY_NAMETAGS = (actionKeys F_KEY_NAMETAGS) select 0;
@@ -71,23 +74,23 @@ F_KEYDOWN_NAMETAG = {
 	waitUntil {scriptDone f_script_briefing};
 
 	//TODO add color section
-	_bstr = format ["<br/>Toggle nametags for friendly units by pressing %1. This displays nametags for units within %3 m.
+	_bstr = format ["<br/><font size='18'>F3 NAMETAGS</font><br/>Toggle nametags for friendly units by pressing %1. This displays nametags for units within %3 m.
 	",F_KEYNAME_NAMETAGS, F_KEY_NAMETAGS,F_DIST_NAMETAGS];
 
-	_bstr = _bstr + "<br/><br/>DISPLAY RADIUS<br/>Nametags can be displayed for only the targeted unit or in a 360° radius. To toggle this feature <execute expression=""
-		if (f_cursortarget_nametags) then {hintsilent 'Full radius display activated!';f_cursortarget_nametags= false} else {f_cursortarget_nametags = true;hintsilent 'Cursor display activated!'};""
+	_bstr = _bstr + "<br/><br/><font size='18'>DISPLAY RADIUS</font><br/>Nametags can be displayed for only the targeted unit or in a 360° radius. To toggle this feature <execute expression=""
+		if (f_cursortarget_nametags) then [{hintsilent 'Full radius display activated!';f_cursortarget_nametags= false},{f_cursortarget_nametags = true;hintsilent 'Cursor display activated!'}];""
 		>click here</execute>.";
 
-	_bstr = _bstr + "<br/><br/>GROUP NAMES<br/>Nametags display the unit's group name. To toggle this feature <execute expression=""
-	if (F_SHOWGROUP_NAMETAGS) then {hintsilent 'Group display deactivated!';F_SHOWGROUP_NAMETAGS= false} else {F_SHOWGROUP_NAMETAGS = true;hintsilent 'Group display activated!'};""
+	_bstr = _bstr + "<br/><br/><font size='18'>GROUP NAMES</font><br/>Nametags can show group name's next to friendly units who are not in your own group. To toggle this feature <execute expression=""
+	if (F_SHOWGROUP_NAMETAGS) then [{hintsilent 'Group display deactivated!';F_SHOWGROUP_NAMETAGS= false},{F_SHOWGROUP_NAMETAGS = true;hintsilent 'Group display activated!'}];""
 	>click here</execute>.";
 
-	_bstr = _bstr + "<br/><br/>DISTANCE<br/>Nametags display the unit's relative distance to you. To toggle this feature <execute expression=""
-	if (F_SHOWDISTANCE_NAMETAGS) then {hintsilent 'Distance display deactivated!';F_SHOWDISTANCE_NAMETAGS= false} else {F_SHOWDISTANCE_NAMETAGS = true;hintsilent 'Distance display activated!'};""
+	_bstr = _bstr + "<br/><br/><font size='18'>DISTANCE</font><br/>Nametags can display the unit's relative distance to yourself. To toggle this feature <execute expression=""
+	if (F_SHOWDISTANCE_NAMETAGS) then [{hintsilent 'Distance display deactivated!';F_SHOWDISTANCE_NAMETAGS= false},{F_SHOWDISTANCE_NAMETAGS = true;hintsilent 'Distance display activated!'}];""
 	>click here</execute>.";
 
-	_bstr = _bstr + "<br/><br/>VEHICLE TYPES<br/>Nametags display the vehicle type of any mounted units. To toggle this feature <execute expression=""
-	if (F_SHOWVEHICLE_NAMETAGS) then {hintsilent 'Vehicle type display deactivated!';F_SHOWVEHICLE_NAMETAGS= false} else {F_SHOWVEHICLE_NAMETAGS = true;hintsilent 'Vehicle type display activated!'};""
+	_bstr = _bstr + "<br/><br/><font size='18'>VEHICLE TYPES</font><br/>Nametags can display the vehicle type under the driver's name. To toggle this feature <execute expression=""
+	if (F_SHOWVEHICLE_NAMETAGS) then [{hintsilent 'Vehicle type display deactivated!';F_SHOWVEHICLE_NAMETAGS= false},{F_SHOWVEHICLE_NAMETAGS = true;hintsilent 'Vehicle type display activated!'}];""
 	>click here</execute>.";
 
 	player createDiaryRecord ["Diary", ["F3 NameTags",_bstr]];

--- a/f/nametag/f_nametags.sqf
+++ b/f/nametag/f_nametags.sqf
@@ -139,7 +139,7 @@ addMissionEventHandler ["Draw3D", {
 			// Filter entities
 			if (
 				// Only for the player's side
-				side _x == side player &&
+				(faction _x == faction player || side _x == side player || group _x == group player) &&
 				// Only other players & no virtual units
 				{_x != player && !(player iskindof "VirtualMan_F")}
 				)

--- a/f/nametag/fn_drawNametag.sqf
+++ b/f/nametag/fn_drawNametag.sqf
@@ -7,14 +7,15 @@ private ["_u","_pos","_suffix","_color","_str","_height"];
 // Declare variables
 _u = _this select 0;
 _pos = _this select 1;
-_height = f_height_standing_Nametags;
+_height =
 switch (stance _u) do {
     case "CROUCH": {
-    	_height = f_height_crouch_Nametags;
+    	f_height_crouch_Nametags;
     };
     case "PRONE": {
-		_height = f_height_prone_Nametags;
+		f_height_prone_Nametags;
 	};
+	default {f_height_standing_Nametags};
 };
 _suffix = if (count _this > 2) then {_this select 2} else {""};
 

--- a/f/nametag/fn_drawNametag.sqf
+++ b/f/nametag/fn_drawNametag.sqf
@@ -29,15 +29,15 @@ _color = F_COLOR_NAMETAGS; // Default color
 if (_suffix != "") then {_color = F_COLOR2_NAMETAGS};						 // Mounted units
 if(_x in units player) then { _color = f_groupColor_Nametags }; // Units of same group
 
-if (F_SHOWGROUP_NAMETAGS) then {_str = format ["%1 ",groupID (group _u)] + _str};
+if (F_SHOWGROUP_NAMETAGS && group _u != group player) then {_str = format ["%1 ",groupID (group _u)] + _str};
 	drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,F_SIZE_NAMETAGS, F_FONT_NAMETAGS];
 
 if (F_SHOWDISTANCE_NAMETAGS) then {
-	_str = format ["%1 m",round (_pos distance player)];
-	drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) - 0.15 + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,F_SIZE_NAMETAGS - 0.15, F_FONT_NAMETAGS];
+	_str = format ["%1m",round (_pos distance player)];
+	drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) - 0.1 + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,F_SIZE_NAMETAGS - 0.15, F_FONT_NAMETAGS];
 };
 
 if (F_SHOWVEHICLE_NAMETAGS && !(typeOf (vehicle _u) isKindof "Man") && (assignedVehicleRole _u select 0 != "Cargo")) then {
 	_str = format ["%1",getText (configFile >> "CfgVehicles" >> (typeOf _veh) >> "displayname")];
-  drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) - 0.25 + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,F_SIZE_NAMETAGS - 0.15, F_FONT_NAMETAGS];
+  drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) - 0.2 + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,F_SIZE_NAMETAGS - 0.15, F_FONT_NAMETAGS];
 };

--- a/f/nametag/fn_drawNametag.sqf
+++ b/f/nametag/fn_drawNametag.sqf
@@ -30,14 +30,15 @@ if (_suffix != "") then {_color = F_COLOR2_NAMETAGS};						 // Mounted units
 if(_x in units player) then { _color = f_groupColor_Nametags }; // Units of same group
 
 if (F_SHOWGROUP_NAMETAGS && group _u != group player) then {_str = format ["%1 ",groupID (group _u)] + _str};
-	drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,F_SIZE_NAMETAGS, F_FONT_NAMETAGS];
 
 if (F_SHOWDISTANCE_NAMETAGS) then {
-	_str = format ["%1m",round (_pos distance player)];
-	drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) - 0.1 + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,F_SIZE_NAMETAGS - 0.15, F_FONT_NAMETAGS];
+	_str = _str + format [" - %1m",round (_pos distance player)];
+	//drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) - _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,(F_SIZE_NAMETAGS - 0.005), F_FONT_NAMETAGS];
 };
 
+drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,F_SIZE_NAMETAGS, F_FONT_NAMETAGS];
+
 if (F_SHOWVEHICLE_NAMETAGS && !(typeOf (vehicle _u) isKindof "Man") && (assignedVehicleRole _u select 0 != "Cargo")) then {
-	_str = format ["%1",getText (configFile >> "CfgVehicles" >> (typeOf _veh) >> "displayname")];
-  drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) - 0.2 + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,F_SIZE_NAMETAGS - 0.15, F_FONT_NAMETAGS];
+  _str = format ["%1",getText (configFile >> "CfgVehicles" >> (typeOf _veh) >> "displayname")];
+  drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) - 0.25 + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,(F_SIZE_NAMETAGS - 0.005), F_FONT_NAMETAGS];
 };

--- a/f/nametag/fn_drawNametag.sqf
+++ b/f/nametag/fn_drawNametag.sqf
@@ -2,7 +2,7 @@
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 // ====================================================================================
 
-private ["_u","_pos","_suffix","_color","_str","_height"];
+private ["_u","_pos","_suffix","_color","_str","_height","_showgroup","_showdis","_showveh","_veh"];
 
 // Declare variables
 _u = _this select 0;
@@ -26,19 +26,27 @@ if (!alive _u) exitWith {};
 
 // Define the color of the nametag
 _color = F_COLOR_NAMETAGS; // Default color
-if (_suffix != "") then {_color = F_COLOR2_NAMETAGS};						 // Mounted units
+if (_suffix != "") then {_color = F_COLOR2_NAMETAGS};			// Mounted units
 if(_x in units player) then { _color = f_groupColor_Nametags }; // Units of same group
 
-if (F_SHOWGROUP_NAMETAGS && group _u != group player) then {_str = format ["%1 ",groupID (group _u)] + _str};
+// Check which tags to show
+_showgroup = if (!isNil "F_SHOWGROUP_NAMETAGS") then [{F_SHOWGROUP_NAMETAGS},{false}];
+_showdis = if (!isNil "F_SHOWDISTANCE_NAMETAGS") then [{F_SHOWDISTANCE_NAMETAGS},{false}];
+_showveh = if (!isNil "f_showVehicle_Nametags") then [{f_showVehicle_Nametags},{false}];
 
-if (F_SHOWDISTANCE_NAMETAGS) then {
+// Show group name for other groups only
+if (_showgroup && group _u != group player) then {_str = format ["%1 ",groupID (group _u)] + _str};
+
+// Show distance for units in over 3m distance only
+if (_showdis && {_pos distance player >= 3}) then {
 	_str = _str + format [" - %1m",round (_pos distance player)];
 	//drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) - _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,(F_SIZE_NAMETAGS - 0.005), F_FONT_NAMETAGS];
 };
 
 drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,F_SIZE_NAMETAGS, F_FONT_NAMETAGS];
 
-if (F_SHOWVEHICLE_NAMETAGS && !(typeOf (vehicle _u) isKindof "Man") && (assignedVehicleRole _u select 0 != "Cargo")) then {
-  _str = format ["%1",getText (configFile >> "CfgVehicles" >> (typeOf _veh) >> "displayname")];
-  drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) - 0.25 + _height], 0, 0, 0, _str, F_SHADOW_NAMETAGS,(F_SIZE_NAMETAGS - 0.005), F_FONT_NAMETAGS];
+// Show vehicle type only for vehicles the player is not crewing himself
+if (_showveh && {!(typeOf (vehicle _u) isKindof "Man") && vehicle _u != vehicle player && ((_u == driver vehicle _u) || (_u == gunner vehicle _u))}) then {
+  _str = format ["%1",getText (configFile >> "CfgVehicles" >> (typeOf vehicle _u) >> "displayname")];
+  drawIcon3D ["", _color, [_pos select 0,_pos select 1,(getPosATL _x select 2) + _height - 0.2], 0, 0, 0, _str,F_SHADOW_NAMETAGS,F_SIZE_NAMETAGS,F_FONT_NAMETAGS];
 };

--- a/f/simplewoundingsystem/init.sqf
+++ b/f/simplewoundingsystem/init.sqf
@@ -27,7 +27,7 @@ Players can drag a casualty by moving next to them and selecting the relevant ac
 <br/><br/>
 BLEEDING OUT<br/>
 An incapacitated player only has a few minutes before her/his wounds become fatal and they die."];
-		player createDiaryRecord ["Diary", ["Simple Wounding System",_bstr]];
+		player createDiaryRecord ["Diary", ["F3 Simple Wounding System",_bstr]];
 	};
 };
 

--- a/init.sqf
+++ b/init.sqf
@@ -136,10 +136,7 @@ if(isServer) then {
 // F3 - Name Tags
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 
-// f_showGroup_Nametags = true;				// Display unit's group (uses GroupID)
-// f_showDistance_Nametags = true;			// Show distance to player
-// f_showVehicle_Nametags = true;			// Show vehicle player is in
-// [20] execVM "f\nametag\f_nametags.sqf";
+// [] execVM "f\nametag\f_nametags.sqf";
 
 // ====================================================================================
 

--- a/init.sqf
+++ b/init.sqf
@@ -136,7 +136,7 @@ if(isServer) then {
 // F3 - Name Tags
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 
-// [] execVM "f\nametag\f_nametags.sqf";
+[] execVM "f\nametag\f_nametags.sqf";
 
 // ====================================================================================
 

--- a/init.sqf
+++ b/init.sqf
@@ -136,7 +136,7 @@ if(isServer) then {
 // F3 - Name Tags
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 
-[] execVM "f\nametag\f_nametags.sqf";
+// [] execVM "f\nametag\f_nametags.sqf";
 
 // ====================================================================================
 


### PR DESCRIPTION
* Can now be displayed for units in radius+cursorTarget or only your cursortarget (toggleable by briefing, default distance for radius is 10m and cursorTarget is 25m)
* Groupname is not added to units of the player's group (if enabled)
* Does not show any tags for units in vehicle cargo, unless they are in player's group
* On distance tags for vehicles show only the effectiveCommander (+ cargo slots)
* Tweaked display values (slightly smaller font and less spacing between lines)
* Moved global variables from init to f_nameTags.sqf
* Made distance a global variable instead of a parameter
* Cleared up and tweaked briefing entry
* Code cleanup, less if/else mostly
* Defaults nametags to on (if component is activated)