### PR TITLE
ACRE2 API Updates

### DIFF
--- a/f/radios/acre2/acre2_clientInit.sqf
+++ b/f/radios/acre2/acre2_clientInit.sqf
@@ -2,41 +2,65 @@
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 
 // ====================================================================================
-// Set channels acording to side.
-_ret = ["ACRE_PRC148", str (side player) ] call acre_api_fnc_setDefaultChannels;
-_ret = ["ACRE_PRC343", str (side player) ] call acre_api_fnc_setDefaultChannels;
-_ret = ["ItemRadio", str (side player) ] call acre_api_fnc_setDefaultChannels;
+// Set up the radio presets according to side.
+_presetName = switch(side player) do {
+	case west:{"default2"};
+	case east:{"default3"};
+	case resistance:{"default4"};
+	default {"default"};
+};
+if (f_radios_settings_acre2_disableFrequencySplit) then {
+	_presetName = "default";
+};
 
-
+_ret = ["ACRE_PRC343", _presetName ] call acre_api_fnc_setPreset;
+_ret = ["ACRE_PRC148", _presetName ] call acre_api_fnc_setPreset;
+_ret = ["ACRE_PRC152", _presetName ] call acre_api_fnc_setPreset;
+_ret = ["ACRE_PRC117F", _presetName ] call acre_api_fnc_setPreset;
+_ret = ["ItemRadio", _presetName ] call acre_api_fnc_setPreset;
 
 
 // if dead, set spectator and exit
 if(!alive player) exitWith {[true] call acre_api_fnc_setSpectator;};
 
-
 _unit = player;
+
+// ====================================================================================
+
+// Set language of the units depending on side (BABEL API)
+switch (side _unit) do {
+	case blufor: {
+		f_radios_settings_acre2_language_blufor call acre_api_fnc_babelSetSpokenLanguages;
+		[f_radios_settings_acre2_language_blufor select 0] call acre_api_fnc_babelSetSpeakingLanguage;
+	};
+	case opfor: {
+		f_radios_settings_acre2_language_opfor call acre_api_fnc_babelSetSpokenLanguages;
+		[f_radios_settings_acre2_language_opfor select 0] call acre_api_fnc_babelSetSpeakingLanguage;
+	};
+	case independent: {
+		f_radios_settings_acre2_language_indfor call acre_api_fnc_babelSetSpokenLanguages;
+		[f_radios_settings_acre2_language_indfor select 0] call acre_api_fnc_babelSetSpeakingLanguage;
+	};
+	default {
+		f_radios_settings_acre2_language_indfor call acre_api_fnc_babelSetSpokenLanguages;
+		[f_radios_settings_acre2_language_indfor select 0] call acre_api_fnc_babelSetSpeakingLanguage;
+	};
+};
+
+// ====================================================================================
+
+// RADIO ASSIGNMENT
 
 // Wait for gear assignation to take place
 waitUntil{(player getVariable ["f_var_assignGear_done", false])};
 _typeOfUnit = _unit getVariable ["f_var_assignGear", "NIL"];
+
 // REMOVE ALL RADIOS
 // Wait for ACRE2 to initialise any radios the unit has in their inventory, and then
 // remove them to ensure that duplicate radios aren't added by accident.
 
-// Remove any already assigned radios
-_unit unlinkItem "ItemRadio";
-
-// Make sure the player doesn't have a radio in their inventory
-if([_unit] call acre_api_fnc_hasRadio) then {
-
-  // Wait for radios to get initialised by ACRE
-  waitUntil{(count ([] call acre_api_fnc_getCurrentRadioList)) > 0};
-
-  // Remove initialised radios
-  {_unit unlinkItem _x;}foreach ([] call acre_api_fnc_getCurrentRadioList);
-
-};
-
+waitUntil{[] call acre_api_fnc_isInitialized};
+{_unit removeItem _x;} forEach ([] call acre_api_fnc_getCurrentRadioList);
 // ====================================================================================
 
 // ASSIGN RADIOS TO UNITS
@@ -50,48 +74,46 @@ if(_typeOfUnit != "NIL") then {
       // Everyone gets a short-range radio by default
       if(isnil "f_radios_settings_acre2_shortRange") then
       {
-        _unit addItem f_radios_settings_acre2_standardSHRadio;
+		if (_unit canAdd f_radios_settings_acre2_standardSHRadio) then
+		{
+			_unit addItem f_radios_settings_acre2_standardSHRadio;
+		} else {
+			f_radios_settings_acre2_standardSHRadio call f_radios_acre2_giveRadioAction;
+		};
       }
       else
       {
         if(_typeOfUnit in f_radios_settings_acre2_shortRange) then
         {
-          _unit addItem f_radios_settings_acre2_standardSHRadio;
+			if (_unit canAdd f_radios_settings_acre2_standardSHRadio) then
+			{
+				_unit addItem f_radios_settings_acre2_standardSHRadio;
+			} else {
+				f_radios_settings_acre2_standardSHRadio call f_radios_acre2_giveRadioAction;
+			};
         };
       };
 
       // If unit is in the above list, add a 148
       if(_typeOfUnit in f_radios_settings_acre2_longRange) then {
-
-        _unit addItem f_radios_settings_acre2_standardLRRadio;
+		if (_unit canAdd f_radios_settings_acre2_standardLRRadio) then
+		{
+			_unit addItem f_radios_settings_acre2_standardLRRadio;
+		} else {
+			f_radios_settings_acre2_standardLRRadio call f_radios_acre2_giveRadioAction;
+		};
 
         // If unit is in the list of units that receive an extra long-range radio, add another 148
         if(_typeOfUnit in f_radios_settings_acre2_extraRadios) then {
-          _unit addItem f_radios_settings_acre2_extraRadio;
+			if (_unit canAdd f_radios_settings_acre2_extraRadio) then
+			{
+				_unit addItem f_radios_settings_acre2_extraRadio;
+			} else {
+				f_radios_settings_acre2_extraRadio call f_radios_acre2_giveRadioAction;
+			};
         };
 
       };
 
   };
-};
-// ====================================================================================
-
-// Set language of the units depending on side (BABEL API)
-switch (side _unit) do {
-    case blufor: {
-    	f_radios_settings_acre2_language_blufor call acre_api_fnc_babelSetSpokenLanguages;
-      [f_radios_settings_acre2_language_blufor select 0] call acre_api_fnc_babelSetSpeakingLanguage;
-    };
-    case opfor: {
-    	f_radios_settings_acre2_language_opfor call acre_api_fnc_babelSetSpokenLanguages;
-      [f_radios_settings_acre2_language_opfor select 0] call acre_api_fnc_babelSetSpeakingLanguage;
-    };
-    case independent: {
-    	f_radios_settings_acre2_language_indfor call acre_api_fnc_babelSetSpokenLanguages;
-      [f_radios_settings_acre2_language_indfor select 0] call acre_api_fnc_babelSetSpeakingLanguage;
-    };
-    default {
-     	f_radios_settings_acre2_language_indfor call acre_api_fnc_babelSetSpokenLanguages;
-      [f_radios_settings_acre2_language_indfor select 0] call acre_api_fnc_babelSetSpeakingLanguage;
-    };
 };

--- a/f/radios/acre2/acre2_init.sqf
+++ b/f/radios/acre2/acre2_init.sqf
@@ -7,12 +7,43 @@ f_acre2_presetSetup = compile preprocessFileLineNumbers "f\radios\acre2\acre2_se
 f_acre2_clientInit = compile preprocessFileLineNumbers "f\radios\acre2\acre2_clientInit.sqf";
 f_fnc_GiveSideRadio = compile preprocessFileLineNumbers "f\radios\acre2\fn_giveSideRadio.sqf";
 
+f_radios_acre2_giveRadioAction = {
+	private["_x"];
+	_x = _this;
+	_unit = player;
+		//Give the player a message so it isn't forgotten about during the briefing.
+	[_x] spawn {
+		waitUntil{time>3};
+		systemChat format["[F3 ACRE2] Warning: No room to add radio '%1', report this to the mission maker. You now have a scroll-wheel action to get this radio.",_this select 0];
+	};
+	
+	//Create addAction to give radio.
+	_radioName = getText (configfile >> "CfgWeapons" >> _x >> "displayName");
+	_actionID = _unit addAction [format ["<t color='#3375D6'>[Radios] Give myself a %1 radio</t>",_radioName],
+		 {
+			 _radioToGive = (_this select 3) select 0;
+			 _unit = (_this select 0),
+			 if (_unit canAdd _radioToGive) then {
+				_unit addItem _radioToGive;
+				_unit removeAction (_this select 2);
+			 } else {
+				 systemChat format["[F3 ACRE2] Warning: No room to add radio '%1', remove more stuff and try again",_radioToGive];
+			 };
+		 }
+		 ,[_x],0,false,false,"","(_target == _this)"];
+	[_actionID,_unit] spawn {
+		sleep 300;
+		if (!isNull (_this select 1)) then {
+			(_this select 1) removeAction (_this select 0);
+		};
+	};
+};
 
 
 // jip check
 if (!isDedicated && (isNull player)) then
 {
-    waitUntil {sleep 0.1; !isNull player};
+	waitUntil {sleep 0.1; !isNull player};
 };
 
 // include the smaller acre2 settings file.
@@ -24,7 +55,7 @@ _presetSetup = [] call f_acre2_presetSetup;
 
 
 // run client stuff.
-if(!isDedicated) then
+if (hasInterface) then 
 {
 	// define our languages (need to be the same order for everyone)
 	{

--- a/f/radios/acre2/acre2_settings.sqf
+++ b/f/radios/acre2/acre2_settings.sqf
@@ -8,10 +8,9 @@
 // TRUE = Disable radios for all units
 f_radios_settings_acre2_disableRadios = FALSE;
 
-// Whether or not the frequencies should be left at default, and not split per side
+// Whether or not the radio frequencies should be left as default, and not split per side
 // TRUE = Disable frequency seperation across sides
 f_radios_settings_acre2_disableFrequencySplit = FALSE;
-
 
 // Set a list of units that get a short wave
 // if its nil, that means all units get a radio
@@ -19,18 +18,18 @@ f_radios_settings_acre2_disableFrequencySplit = FALSE;
 f_radios_settings_acre2_shortRange = nil;
 
 // Set the list of units that get a long range
-f_radios_settings_acre2_longRange = ["co", "dc", "m", "mmgg", "matg", "mtrg", "sn","vc", "pp", "eng", "engm", "uav", "div"];
+f_radios_settings_acre2_longRange = ["co", "dc", "m", "mmgag","hmgag","matag","hatag", "mtrag","msamag","sp","vc", "pp", "eng", "engm", "uav", "div"];
 
 // Unit types you want to give an extra long-range radio
 // E.G: ["co", "m"] would give the CO and all medics an extra long-range radios
-f_radios_settings_acre2_extraRadios = [""];
+f_radios_settings_acre2_extraRadios = [];
 
 // Standard Short
 f_radios_settings_acre2_standardSHRadio = "ACRE_PRC343";
 // Standard LongRange
-f_radios_settings_acre2_standardLRRadio = "ACRE_PRC148";
+f_radios_settings_acre2_standardLRRadio = "ACRE_PRC152";
 // Extra radio
-f_radios_settings_acre2_extraRadio = "ACRE_PRC148";
+f_radios_settings_acre2_extraRadio = "ACRE_PRC117F";
 
 // ====================================================================================
 // BABEL API
@@ -45,14 +44,29 @@ f_radios_settings_acre2_language_blufor = ["english"];
 f_radios_settings_acre2_language_opfor = ["farsi"];
 f_radios_settings_acre2_language_indfor = ["greek"];
 
-// radio frequency offset for each side
-f_radios_settings_acre2_offset_blufor = 0.25;
-f_radios_settings_acre2_offset_opfor = 0.52;
-f_radios_settings_acre2_offset_indfor = 1.02;
-
-
 // Channels names
 // first item in the array will correspond to the first channel
+// note these only work if f_radios_settings_acre2_disableFrequencySplit is set to false
 f_radios_settings_acre2_groups_blufor = ["Alpha","Bravo","Charlie","Delta","Echo","Foxtrot","Golf","Hotel","India","Juliet","Kilo","Lima","Mike","November","Oscar","Papa","Quebec","Romeo","Sierra","Tango","Uniform","Victor","Whiskey","X-ray","Yankee","Zulu"];
 f_radios_settings_acre2_groups_opfor = ["Alpha","Bravo","Charlie","Delta","Echo","Foxtrot","Golf","Hotel","India","Juliet","Kilo","Lima","Mike","November","Oscar","Papa","Quebec","Romeo","Sierra","Tango","Uniform","Victor","Whiskey","X-ray","Yankee","Zulu"];
 f_radios_settings_acre2_groups_indfor = ["Alpha","Bravo","Charlie","Delta","Echo","Foxtrot","Golf","Hotel","India","Juliet","Kilo","Lima","Mike","November","Oscar","Papa","Quebec","Romeo","Sierra","Tango","Uniform","Victor","Whiskey","X-ray","Yankee","Zulu"];
+
+// ====================================================================================
+// MISC ACRE2 settings, these are all set the ACRE2 defaults
+
+// ACRE Radio loss settings.
+// Indiciates how much terrian loss should be modelled.
+// Values: 0 no loss, 1 full terrian loss, default: 1
+[1] call acre_api_fnc_setLossModelScale;
+
+// ACRE full Duplex
+// Sets the duplex of radio transmissions. If set to true, it means that you will receive transmissions even while talking and multiple people can speak at the same time.
+[false] call acre_api_fnc_setFullDuplex;
+
+// ACRE Interference
+// Sets whether transmissions will interfere with eachother. This, by default, causes signal loss when multiple people are transmitting on the same frequency.
+[true] call acre_api_fnc_setInterference;
+
+// ACRE can AI hear players?
+// False - AI not hear players, true - AI hear players.
+[false] call acre_api_fnc_setRevealToAI;

--- a/f/radios/acre2/acre2_setupPresets.sqf
+++ b/f/radios/acre2/acre2_setupPresets.sqf
@@ -2,148 +2,35 @@
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 // ====================================================================================
 
-// include ACRE2 macros
-#include "\idi\clients\acre\addons\api\script_component.hpp"
-
-// ====================================================================================
-// Setup 148 preset for all sides
+//Set the names for all the radios properly.
 {
-        _offset = 0;
-        _channelNames = [];
-        _override = [];
-        switch(_x) do
-        {
-                case blufor:
-                {
-                        _offset = f_radios_settings_acre2_offset_blufor;
-                        _channelNames = f_radios_settings_acre2_groups_blufor;
-                };
-                case opfor:
-                {
-                        _offset = f_radios_settings_acre2_offset_opfor;
-                        _channelNames = f_radios_settings_acre2_groups_opfor;
-                };
-                case independent:
-                {
-                        _offset = f_radios_settings_acre2_offset_indfor;
-                        _channelNames = f_radios_settings_acre2_groups_indfor;
-                };
-        };
-
-        _presetData = HASH_CREATE;
-        _channels = HASHLIST_CREATELIST(["power"]);
-
-        for "_i" from 0 to 31 do {
-                // create a hashlist
-                _channel = HASHLIST_CREATEHASH(_channels);
-
-                // append the offset to the frequency
-                _frequency = 30+((_i)+_offset);
-
-                // Set the frequency
-                HASH_SET(_channel,"frequencyTX",_frequency);
-                HASH_SET(_channel,"frequencyRX",_frequency);
-
-                // set the basic settings power settings and encryption
-                HASH_SET(_channel,"power",5000);
-                HASH_SET(_channel,"encryption",0);
-                HASH_SET(_channel,"channelMode", "BASIC");
-
-
-                // If there's not a set name to use, just use the name of the side + the channel number
-                if(_i >= (count _channelNames)) then
-                {
-                        HASH_SET(_channel,"label",(str _x)+ " "+ str(_i+1));
-                }
-                else
-                {
-                        HASH_SET(_channel,"label",(_channelNames select _i));
-                };
-                // CTCSS
-                // http://en.wikipedia.org/wiki/Continuous_Tone-Coded_Squelch_System
-                HASH_SET(_channel,"CTCSSTx", 250.3);
-                HASH_SET(_channel,"CTCSSRx", 250.3);
-
-                // Settings, default don't change.
-                HASH_SET(_channel,"modulation","FM");
-                HASH_SET(_channel,"trafficRate",16);
-                HASH_SET(_channel,"TEK",1);
-                HASH_SET(_channel,"RPTR",0.2);
-                HASH_SET(_channel,"fade",2);
-                HASH_SET(_channel,"phase",256);
-                HASH_SET(_channel,"squelch",3);
-
-                // Push the channels to the hashlist
-                HASHLIST_PUSH(_channels, _channel);
-        };
-
-        // Assign the channels to the proper groups.
-        HASH_SET(_presetData,"channels",_channels);
-        _groups = [
-                        ["G01", [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]],
-                        ["G02", [16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]],
-                        ["G03", []],
-                        ["G04", []],
-                        ["G05", []],
-                        ["G06", []],
-                        ["G07", []],
-                        ["G08", []],
-                        ["G09", []],
-                        ["G11", []],
-                        ["G12", []],
-                        ["G13", []],
-                        ["G14", []],
-                        ["G15", []],
-                        ["G16", []]
-        ];
-        HASH_SET(_presetData,"groups",_groups);
-
-        // save the preset as "WEST"
-        ["ACRE_PRC148",str _x,_presetData] call CALLSTACK(acre_sys_data_fnc_registerRadioPreset);
-
-} foreach [blufor,opfor,independent];
-
-// ====================================================================================
-// Setup 343 presets for all sides
-
-{
-        _offset = 0;
-
-        switch(_x) do
-        {
-                case blufor:
-                {
-                        _offset = f_radios_settings_acre2_offset_blufor;
-                };
-                case opfor:
-                {
-                        _offset = f_radios_settings_acre2_offset_opfor;
-                };
-                case independent:
-                {
-                        _offset = f_radios_settings_acre2_offset_indfor;
-                };
-                default
-                {
-                        _offset = f_radios_settings_acre2_offset_indfor;
-                };
-        };
-
-        _presetData = HASH_CREATE;
-        _channels = HASHLIST_CREATELIST(["frequencyTX"]);
-
-
-        for "_i" from 0 to 15 do {
-                _channel = HASHLIST_CREATEHASH(_channels);
-                HASH_SET(_channel,"frequencyTX",(2400+(_i))+(_offset));
-                HASHLIST_PUSH(_channels, _channel);
-        };
-        HASH_SET(_presetData,"channels",_channels);
-
-
-
-        ["ACRE_PRC343",str _x,_presetData] call CALLSTACK(acre_sys_data_fnc_registerRadioPreset);
-        ["ItemRadio",str _x,_presetData] call CALLSTACK(acre_sys_data_fnc_registerRadioPreset);
-
-} foreach [blufor,opfor,independent];
-
+	_radioName = _x;
+	_nameField = switch (_radioName) do {
+					case "ACRE_PRC152": {"description"};
+					case "ACRE_PRC148": {"label"};
+					case "ACRE_PRC117F": {"name"};
+					default {""};
+				};
+				
+	_counter = 1;			
+	{
+		_channelName = _x;
+		[_radioName, "default2", _counter, _nameField, _x] call acre_api_fnc_setPresetChannelField;
+		_counter = _counter + 1;
+	} forEach f_radios_settings_acre2_groups_blufor;
+	
+	_counter = 1;
+	{
+		_channelName = _x;
+		[_radioName, "default3", _counter, _nameField, _x] call acre_api_fnc_setPresetChannelField;
+		_counter = _counter + 1;
+	} forEach f_radios_settings_acre2_groups_opfor;
+	
+	_counter = 1;
+	{
+		_channelName = _x;
+		[_radioName, "default4", _counter, _nameField, _x] call acre_api_fnc_setPresetChannelField;
+		_counter = _counter + 1;
+	} forEach f_radios_settings_acre2_groups_indfor;
+	
+} forEach ["ACRE_PRC148","ACRE_PRC152","ACRE_PRC117F"];

--- a/f/radios/acre2/fn_giveSideRadio.sqf
+++ b/f/radios/acre2/fn_giveSideRadio.sqf
@@ -9,7 +9,14 @@ _unit = _this select 0;
 _side = _this select 1;
 _radio = _this select 2;
 
+_presetName = switch(_side) do {
+	case west:{"default2"};
+	case east:{"default3"};
+	case resistance:{"default4"};
+	default {"default"};
+};
+
 // must be local.
 if (!local _unit) ExitWith {};
-_ret = [_radio, str _side] call acre_api_fnc_setDefaultChannels;
+_ret = [_radio, _presetName] call acre_api_fnc_setDefaultChannels;
 _unit addItem _radio;


### PR DESCRIPTION
Updated to the latest API (removing un-neccesary code)
Adds support for the newer radios.
Checks if players have enough free inventory space for radios and provides an action if not.