### PR TITLE
Temporary fix for acre_api_fnc_isInitialized ignoring itemRadio. 

### DIFF
--- a/f/radios/acre2/acre2_clientInit.sqf
+++ b/f/radios/acre2/acre2_clientInit.sqf
@@ -59,6 +59,9 @@ _typeOfUnit = _unit getVariable ["f_var_assignGear", "NIL"];
 // Wait for ACRE2 to initialise any radios the unit has in their inventory, and then
 // remove them to ensure that duplicate radios aren't added by accident.
 
+waitUntil{uiSleep 0.3; !("ItemRadio" in (items _unit + assignedItems _unit))};
+uiSleep 1;
+
 waitUntil{[] call acre_api_fnc_isInitialized};
 {_unit removeItem _x;} forEach ([] call acre_api_fnc_getCurrentRadioList);
 // ====================================================================================


### PR DESCRIPTION
See - http://gitlab.idi-systems.com/idi-systems/acre2-public/issues/18

This can be reverted if/when ACRE2 devs patch the API function.