### PR TITLE
SetGroupIDGlobal (1.48 Command)

### DIFF
--- a/f/setGroupID/f_setGroupIDs.sqf
+++ b/f/setGroupID/f_setGroupIDs.sqf
@@ -2,6 +2,9 @@
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 // ====================================================================================
 
+// Execute only on the server
+if !isServer exitWith {};
+
 // OPEN THE ARRAY CONTAING ALL GROUPS
 // Do not comment or delete this line!
 _groups = [

--- a/f/setGroupID/fn_setGroupID.sqf
+++ b/f/setGroupID/fn_setGroupID.sqf
@@ -12,5 +12,5 @@ if(!isnil (_this select 0)) then {
 	_grp = call compile format ["%1",_this select 0];
 	_name = _this select 1;
 
-	_grp setGroupId [format ["%1",_name],"GroupColor0"];
+	_grp setGroupIdGlobal [format ["%1",_name],"GroupColor0"];
 };


### PR DESCRIPTION
Simple edit to make use of the new setGroupIDGlobal (https://community.bistudio.com/wiki/setGroupIdGlobal) added in 1.48.

f_setGroupIDs would only be registered on the server, and f_fnc_setGroupID only be executed by the server.