### PR TITLE
Mission Conditions changes

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -181,18 +181,22 @@ class Params
 		values[] = {0,1,2,3,4,5,6,7,8,9};
 		texts[] = {$STR_f_param_weather_Option0,$STR_f_param_weather_Option1,$STR_f_param_weather_Option2,$STR_f_param_weather_Option3,$STR_f_param_weather_Option4,$STR_f_param_weather_Option5,$STR_f_param_weather_Option6,$STR_f_param_weather_Option7,$STR_f_param_weather_Option8,$STR_f_param_weather_Option11};
 		default = 0;
-		function = "f_fnc_setWeather";		// This function is called to apply the values
-		isGlobal = 0;						// Execute this only on the server
 	};
 
 	class f_param_fog
 	{
-		title = "Fog";
+		title = "Override Fog";
 		values[] = {0,1,2,4};
-		texts[] = {"None","Light","Heavy","Use mission settings"};
-		default = 0;
-		function = "f_fnc_SetFog";			// This function is called to apply the values
-		isGlobal = 0;						// Execute this only on the server
+		texts[] = {"No Fog","Light Fog","Heavy Fog","Use default"};
+		default = 4;
+	};
+
+	class f_param_wind
+	{
+		title = "Override Wind";
+		values[] = {0,1,2,4};
+		texts[] = {"No Wind","Light Wind","Heavy Wind","Use default"};
+		default = 4;
 	};
 
     class f_param_timeOfDay

--- a/f/common/functions.hpp
+++ b/f/common/functions.hpp
@@ -30,6 +30,7 @@ class F // Defines the "owner"
 		class SetTime{};
 		class SetFog{};
 		class SetWeather{};
+		class SetWind{};
 	};
 	class cache
 	{

--- a/f/missionConditions/f_setMissionConditions.sqf
+++ b/f/missionConditions/f_setMissionConditions.sqf
@@ -1,0 +1,25 @@
+// F3 - Mission Conditions
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+// ====================================================================================
+
+// SCRIPT SHOULD ONLY RUN ON SERVER
+
+if (!isServer) exitWith {};
+
+// ====================================================================================
+
+// SET WEATHER
+// Set the mission weather according to params. If the fog and wind override params
+// are set, then prevent setWeather from setting them and set them manually instead.
+
+[f_param_weather,f_param_fog == 4,f_param_wind == 4] call f_fnc_setWeather;
+
+if (f_param_fog != 4) then {
+	[f_param_fog] call f_fnc_setFog;
+};
+
+if (f_param_wind != 4) then {
+	[f_param_wind] call f_fnc_setWind;
+};
+
+// ====================================================================================

--- a/f/missionConditions/fn_SetWeather.sqf
+++ b/f/missionConditions/fn_SetWeather.sqf
@@ -4,14 +4,16 @@
 
 // DECLARE VARIABLES AND FUNCTIONS
 
-private ["_weather","_missionOvercast","_MissionRain","_MissionRainbow","_MissionLightnings","_MissionWindStr","_MissionWindGusts","_MissionWaves","_MissionHumidity"];
+private ["_missionOvercast","_MissionRain","_MissionRainbow","_MissionLightnings","_MissionWindStr","_MissionWindGusts","_MissionWaves","_MissionHumidity"];
 
 // ====================================================================================
 
 // SET KEY VARIABLES
 // We interpret the values parsed to the script. If the function was called from the parameters those values are used.
 
-_weather = _this select 0;
+params [["_weather",9,[0]],["_setFog",true,[true]],["_setWind",true,[true]]];
+
+systemChat format ["%1",_this];
 
 // Exit when using mission settings
 if ( _weather == 9 ) exitWith {};
@@ -22,10 +24,13 @@ _MissionOvercast = 0;
 _MissionRain = 0;
 _MissionRainbow = 0;
 _MissionLightnings = 0;
-_MissionWindStr = 0;
-_MissionWindGusts = 0;
+_MissionWindStr = 0.01;
+_MissionWindGusts = 0.01;
 _MissionWaves = 0;
 _MissionHumidity = 0;
+_MissionFogStrength = 0;
+_MissionFogDecay = 0;
+_MissionFogBase = 0;
 
 // ====================================================================================
 
@@ -34,22 +39,25 @@ _MissionHumidity = 0;
 
 switch (_weather) do
 {
-// Clear (Calm)
+// Clear
 	case 0:
 	{
 		_MissionOvercast = 0;
 		_MissionRain = 0;
 		_MissionRainbow = 0;
 		_MissionLightnings = 0;
-		_MissionWindStr = 0;
-		_MissionWindGusts = 0;
+		_MissionWindStr = 0.01;
+		_MissionWindGusts = 0.01;
 		_MissionWaves = 0;
 		_MissionHumidity = 0;
+		_MissionFogStrength = 0;
+		_MissionFogDecay = 0;
+		_MissionFogBase = 0;
 	};
-// Clear (Light Winds)
+// Cloudy
 	case 1:
 	{
-		_MissionOvercast = 0.01;
+		_MissionOvercast = 0.25;
 		_MissionRain = 0;
 		_MissionRainbow = 0;
 		_MissionLightnings = 0;
@@ -57,34 +65,13 @@ switch (_weather) do
 		_MissionWindGusts = 0.5;
 		_MissionWaves = 0.25;
 		_MissionHumidity = 0.2;
+		_MissionFogStrength = 0;
+		_MissionFogDecay = 0;
+		_MissionFogBase = 0;
 	};
-// Clear (Strong Winds)
+// Mostly Cloudy
 	case 2:
 	{
-		_MissionOvercast = 0.01;
-		_MissionRain = 0;
-		_MissionRainbow = 0;
-		_MissionLightnings = 0;
-		_MissionWindStr = 0.75;
-		_MissionWindGusts = 1;
-		_MissionWaves = 0.75;
-		_MissionHumidity = 0.2;
-	};
-// Overcast (Calm)
-	case 3:
-	{
-		_MissionOvercast = 0.55;
-		_MissionRain = 0;
-		_MissionRainbow = 0;
-		_MissionLightnings = 0;
-		_MissionWindStr = 0;
-		_MissionWindGusts = 0;
-		_MissionWaves = 0.1;
-		_MissionHumidity = 0.2;
-	};
-// Overcast (Light Winds)
-	case 4:
-	{
 		_MissionOvercast = 0.55;
 		_MissionRain = 0;
 		_MissionRainbow = 0;
@@ -93,42 +80,84 @@ switch (_weather) do
 		_MissionWindGusts = 0.5;
 		_MissionWaves = 0.25;
 		_MissionHumidity = 0.2;
+		_MissionFogStrength = 0;
+		_MissionFogDecay = 0;
+		_MissionFogBase = 0;
 	};
-// Overcast (Strong Winds)
+// Overcast
+	case 3:
+	{
+		_MissionOvercast = 1;
+		_MissionRain = 0;
+		_MissionRainbow = 0;
+		_MissionLightnings = 0;
+		_MissionWindStr = 0.25;
+		_MissionWindGusts = 0.5;
+		_MissionWaves = 0.25;
+		_MissionHumidity = 0.2;
+		_MissionFogStrength = 0;
+		_MissionFogDecay = 0;
+		_MissionFogBase = 0;
+	};
+// Foggy
+	case 4:
+	{
+		_MissionOvercast = 0.9;
+		_MissionRain = 0;
+		_MissionRainbow = 0;
+		_MissionLightnings = 0;
+		_MissionWindStr = 0.25;
+		_MissionWindGusts = 0.5;
+		_MissionWaves = 0.25;
+		_MissionHumidity = 0.2;
+		_MissionFogStrength = 0.3;
+		_MissionFogDecay = 0;
+		_MissionFogBase = 0;
+	};
+// Showers
 	case 5:
 	{
 		_MissionOvercast = 0.55;
-		_MissionRain = 0;
-		_MissionRainbow = 0;
-		_MissionLightnings = 0;
-		_MissionWindStr = 0.75;
-		_MissionWindGusts = 1;
-		_MissionWaves = 0.75;
-		_MissionHumidity = 0.2;
-	};
-// Rain (Light Winds)
-	case 6:
-	{
-		_MissionOvercast = 1;
-		_MissionRain = 1;
-		_MissionRainbow = 0;
+		_MissionRain = 0.1;
+		_MissionRainbow = 0.6;
 		_MissionLightnings = 0;
 		_MissionWindStr = 0.25;
 		_MissionWindGusts = 0.5;
-		_MissionWaves = 0.75;
-		_MissionHumidity = 0.9;
+		_MissionWaves = 0.25;
+		_MissionHumidity = 0.2;
+		_MissionFogStrength = 0.03;
+		_MissionFogDecay = 0;
+		_MissionFogBase = 0;
 	};
-// Rain (Strong Winds)
+// Light Rain
+	case 6:
+	{
+		_MissionOvercast = 1;
+		_MissionRain = 0.2;
+		_MissionRainbow = 0.4;
+		_MissionLightnings = 0;
+		_MissionWindStr = 0.25;
+		_MissionWindGusts = 0.5;
+		_MissionWaves = 0.25;
+		_MissionHumidity = 0.9;
+		_MissionFogStrength = 0.05;
+		_MissionFogDecay = 0;
+		_MissionFogBase = 0;
+	};
+// Heavy Rain
 	case 7:
 	{
 		_MissionOvercast = 1;
-		_MissionRain = 1;
+		_MissionRain = 0.8;
 		_MissionRainbow = 0;
 		_MissionLightnings = 0;
-		_MissionWindStr = 0.75;
+		_MissionWindStr = 0.5;
 		_MissionWindGusts = 1;
-		_MissionWaves = 0.75;
+		_MissionWaves = 0.6;
 		_MissionHumidity = 0.9;
+		_MissionFogStrength = 0.15;
+		_MissionFogDecay = 0;
+		_MissionFogBase = 0;
 	};
 // Storm
 	case 8:
@@ -141,6 +170,9 @@ switch (_weather) do
 		_MissionWindGusts = 1;
 		_MissionWaves = 1;
 		_MissionHumidity = 1;
+		_MissionFogStrength = 0.2;
+		_MissionFogDecay = 0;
+		_MissionFogBase = 0;
 	};
 };
 
@@ -155,19 +187,29 @@ if (typeName _transition == typeName 0) then {
 _transition setOvercast  _MissionOvercast;
 _transition setRain _MissionRain;
 _transition setRainbow _MissionRainbow;
-_transition setWindStr  _MissionWindStr;
-_transition setWindForce _MissionWindGusts;
-_transition setWaves _MissionWaves;
 _transition setLightnings _MissionLightnings;
+if (_setWind) then {
+	_transition setWindStr  _MissionWindStr;
+	_transition setWindForce _MissionWindGusts;
+	_transition setWaves _MissionWaves;
+};
+if (_setFog) then {
+	_transition setFog [_MissionFogStrength,_MissionFogDecay,_MissionFogBase];
+};
 
 } else {
 	0 setOvercast  _MissionOvercast;
 	0 setRain _MissionRain;
 	0 setRainbow _MissionRainbow;
-	0 setWindStr  _MissionWindStr;
-	0 setWindForce _MissionWindGusts;
-	0 setWaves _MissionWaves;
 	0 setLightnings _MissionLightnings;
+	if (_setWind) then {
+		0 setWindStr  _MissionWindStr;
+		0 setWindForce _MissionWindGusts;
+		0 setWaves _MissionWaves;
+	};
+	if (_setFog) then {
+		0 setFog [_MissionFogStrength,_MissionFogDecay,_MissionFogBase];
+	};
 	forceWeatherChange;
 };
 

--- a/f/missionConditions/fn_SetWind.sqf
+++ b/f/missionConditions/fn_SetWind.sqf
@@ -1,0 +1,69 @@
+// F3 - SetWind
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+// ====================================================================================
+
+// DECLARE VARIABLES AND FUNCTIONS
+
+private ["_wind","_strength","_decay","_base"];
+
+// ====================================================================================
+
+// SET KEY VARIABLES
+// We interpret the values parsed to the script. If the function was called from the parameters those values are used.
+
+params [["_wind",4,[0]],["_transition",0,[0]]];
+
+// Exit if we're not overriding
+if ( _wind == 4 ) exitWith {};
+
+_strength = 0.01;	// Base wind strength
+_gusts = 0.01; 		// How fast the wind can change
+_waves = 0; 		// Size of waves
+
+// ====================================================================================
+
+// SELECT FOG VALUES
+// Using the value of _fog, new fog values are set.
+
+switch (_wind) do
+{
+	//None
+	case 0:
+	{
+		_strength = 0.01;
+		_gusts = 0.01;
+		_waves = 0;
+	};
+
+	//Light
+	case 1:
+	{
+		_strength = 0.25;
+		_gusts = 0.5;
+		_waves = 0.25;
+	};
+
+	//Heavy
+	case 2:
+	{
+		_strength = 0.75;
+		_gusts = 1;
+		_waves = 0.25;
+	};
+};
+
+// ====================================================================================
+
+// SET MISSION CONDITIONS
+// Use the new values to set the transition across the network
+
+
+_transition setWindStr  _strength;
+_transition setWindForce _gusts;
+_transition setWaves _waves;
+
+systemChat format ["%1",[_strength,_gusts,_waves]];
+
+// ====================================================================================
+
+

--- a/init.sqf
+++ b/init.sqf
@@ -70,6 +70,13 @@ if(isServer) then {
 
 // ====================================================================================
 
+// F3 - F3 Mission Conditions Selector
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+
+f_script_setMissionConditions = [] execVM "f\missionConditions\f_setMissionConditions.sqf";
+
+// ====================================================================================
+
 // F3 - Automatic Body Removal
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 

--- a/mission.sqm
+++ b/mission.sqm
@@ -222,10 +222,12 @@ class Mission
 		briefingName="*** Insert mission name here. ***";
 		resistanceWest=0;
 		startWeather=0.84999996;
-		startWind=0;
+		startWind=0.25;
+		startGust=0.25;
 		forecastWeather=0.84999996;
-		forecastWind=0;
+		forecastWind=0.25;
 		forecastWaves=0;
+		forecastGust=0.25;
 		rainForced=1;
 		lightningsForced=1;
 		wavesForced=1;

--- a/stringtable.xml
+++ b/stringtable.xml
@@ -88,31 +88,31 @@
       </Key>
       <Key ID="STR_f_param_weather">
         <English> Weather </English>
-	<French> Météo </English>
+        <French> Météo </English>
       </Key>
       <Key ID="STR_f_param_weather_Option0">
-        <English> Clear (Calm)</English>
+        <English> Clear</English>
       </Key>
       <Key ID="STR_f_param_weather_Option1">
-        <English> Clear (Light Winds)</English>
+        <English> Cloudy</English>
       </Key>
       <Key ID="STR_f_param_weather_Option2">
-        <English> Clear (Strong Winds)</English>
+        <English> Mostly Cloudy</English>
       </Key>
       <Key ID="STR_f_param_weather_Option3">
-        <English> Overcast (Calm)</English>
+        <English> Overcast</English>
       </Key>
       <Key ID="STR_f_param_weather_Option4">
-        <English> Overcast (Light Winds)</English>
+        <English> Foggy</English>
       </Key>
       <Key ID="STR_f_param_weather_Option5">
-        <English> Overcast (Strong Winds)</English>
+        <English> Showers</English>
       </Key>
       <Key ID="STR_f_param_weather_Option6">
-        <English> Rain (Light Winds)</English>
+        <English> Light Rain</English>
       </Key>
       <Key ID="STR_f_param_weather_Option7">
-        <English> Rain (Strong Winds)</English>
+        <English> Heavy Rain</English>
       </Key>
       <Key ID="STR_f_param_weather_Option8">
         <English> Storm </English>


### PR DESCRIPTION
#719

The setTime changes appear to work on Tanoa, and are almost identical to the current set up on Altis (Dawn is at 4:49 and a bit instead of 4:50, for example).

Screenshots don't really do them justice but here's the new weather presets: http://imgur.com/a/uqcEy

Also, there's a [bug](https://feedback.bistudio.com/T77382) that prevents wind strength from ever being not zero if it was ever zero that I've worked around.