### PR TITLE
GroupMarker & groupID update

### DIFF
--- a/f/briefing/f_orbatNotes.sqf
+++ b/f/briefing/f_orbatNotes.sqf
@@ -5,7 +5,7 @@
 if (!hasInterface) exitWith {}; //Exit if not a player.
 
 // Group IDs need to be set before the ORBAT listing can be created
-waitUntil {scriptDone f_script_setGroupIDs};
+// waitUntil {scriptDone f_script_setGroupIDs};
 
 // Define needed variables
 private ["_orbatText", "_groups", "_precompileGroups","_maxSlots","_freeSlots"];
@@ -39,7 +39,7 @@ _groups = _groups - _hiddenGroups;
  		};
 	};
 
-	_orbatText = _orbatText + format ["<font color='%3'>%1 %2</font>", _x, name leader _x,_color] + "<br />";
+	_orbatText = _orbatText + format ["<font color='%3'>%1 - %2</font>", _x, name leader _x,_color] + "<br />";
 
 	{
 		if (_x getVariable ["f_var_assignGear",""] == "m" && {_x != leader group _x}) then {

--- a/f/common/functions.hpp
+++ b/f/common/functions.hpp
@@ -19,11 +19,12 @@ class F // Defines the "owner"
 		file = "f\assignGear";
 		class assignGear{};
 	};
-	class setGroupID
+	// TODO REMOVE
+	/*class setGroupID
 	{
 		file = "f\setGroupID";
 		class setGroupID{};
-	};
+	};*/
 	class missionConditions
 	{
 		file = "f\missionConditions";

--- a/f/groupMarkers/f_setLocalGroupMarkers.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers.sqf
@@ -31,407 +31,61 @@ else
 {
 	_unitfaction = (_this select 0);
 };
+
 // ====================================================================================
+
+// CONFIGURE MARKER TYPES
+// Using the marker classes (https://community.bistudio.com/wiki/cfgMarkers) we setup a number of variables to define which type of marker should be used for which group
+// Note: They can be overriden for each group individually
+
+// Groups
+_hq = "b_hq";			// Command elements
+_ft = "b_inf";			// Fireteams
+_sup = "b_support";		// Support units (MMG,HMG)
+_lau = "b_motor_inf";	// Launchers (MAT, HAT)
+_mor = "b_mortar";		// Mortars
+_eng = "b_maint";		// Engineers
+_ifv = "b_mech_inf";	// IFVs & APCs
+_tnk = "b_armor";		// Tanks
+_rec = "b_recon";		// Recon (ST)
+_hel = "b_air";			// Helicopters
+_pla = "b_plane";		// Planes
+_art = "b_art";			// Artillery
+
+// Specialists
+_med = "b_med";			// Medic
+_uav = "b_uav";			// UAV
+
+// ====================================================================================
+
+// INCLUDE GROUP MARKER SCRIPTS
+// Due to the amount of markers the script is split into various sub-scripts (by side)
+// which are now included to create the complete script
+
 switch (_unitfaction) do
 {
-// ====================================================================================
-
-// MARKERS: BLUFOR > NATO
-// Markers seen by players in NATO slots.
-
-	case "blu_f":
-	{
-		["GrpNATO_CO", 0, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_DC", 0, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_COV", 7, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
-
-		["GrpNATO_ASL", 0, "ASL", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_A1", 1, "A1", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_A2", 1, "A2", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_AV", 7, "AV", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["GrpNATO_BSL", 0, "BSL", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_B1", 1, "B1", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_B2", 1, "B2", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_BV", 7, "BV", "ColorBlue"] spawn f_fnc_localGroupMarker;
-
-		["GrpNATO_CSL", 0, "CSL", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_C1", 1, "C1", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_C2", 1, "C2", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_CV", 7, "CV", "ColorGreen"] spawn f_fnc_localGroupMarker;
-
-		["GrpNATO_JSL", 0, "JSL", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_J1", 1, "J1", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_J2", 1, "J2", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_JV", 7, "JV", "ColorPink"] spawn f_fnc_localGroupMarker;
-
-		["GrpNATO_MMG1", 2, "MMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_MMG2", 2, "MMG2", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_HMG1",  2, "HMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_MAT1", 3, "MAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_MAT2", 3, "MAT2", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_HAT1",  3, "HAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_MTR1",  5, "MTR1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_MSAM1",  3, "MSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_HSAM1",  3, "HSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_ST1",  4, "ST1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_DT1",  4, "DT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_ENG1",  6, "ENG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-
- 		["GrpNATO_IFV1",  7, "IFV1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_IFV2",  7, "IFV2", "ColorOrange"] spawn f_fnc_localGroupMarker;
- 		["GrpNATO_TNK1",  8, "TNK1", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["GrpNATO_TH1",  9, "TH1", "ColorRed"] spawn f_fnc_localGroupMarker;
- 		["GrpNATO_TH2",  9, "TH2", "ColorRed"] spawn f_fnc_localGroupMarker;
- 		["GrpNATO_TH3",  9, "TH3", "ColorBlue"] spawn f_fnc_localGroupMarker;
- 		["GrpNATO_TH4",  9, "TH4", "ColorBlue"] spawn f_fnc_localGroupMarker;
- 		["GrpNATO_TH5",  9, "TH5", "ColorGreen"] spawn f_fnc_localGroupMarker;
-  		["GrpNATO_TH6",  9, "TH6", "ColorGreen"] spawn f_fnc_localGroupMarker;
-   		["GrpNATO_TH7",  9, "TH7", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpNATO_TH8",  9, "TH8", "ColorOrange"] spawn f_fnc_localGroupMarker;
-
-		["GrpNATO_AH1",  9, "AH1", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["UnitNATO_CO_M", 0, "COM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitNATO_DC_M", 0, "DCM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitNATO_ASL_M", 0, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitNATO_BSL_M", 0, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitNATO_CSL_M", 0, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-
-	};
 
 // ====================================================================================
 
-// MARKERS: OPFOR > CSAT
-// Markers seen by players in CSAT slots.
+// MARKERS: BLUFOR
+// Markers seen by players in BLUFOR slots
 
-	case "opf_f":
-	{
-		["GrpCSAT_CO", 0, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_DC", 0, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_COV", 7, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
-
-		["GrpCSAT_ASL", 0, "ASL", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_A1", 1, "A1", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_A2", 1, "A2", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_AV", 7, "AV", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["GrpCSAT_BSL", 0, "BSL", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_B1", 1, "B1", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_B2", 1, "B2", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_BV", 7, "BV", "ColorBlue"] spawn f_fnc_localGroupMarker;
-
-		["GrpCSAT_CSL", 0, "CSL", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_C1", 1, "C1", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_C2", 1, "C2", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_CV", 7, "CV", "ColorGreen"] spawn f_fnc_localGroupMarker;
-
-		["GrpCSAT_JSL", 0, "JSL", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_J1", 1, "J1", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_J2", 1, "J2", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_JV", 7, "JV", "ColorPink"] spawn f_fnc_localGroupMarker;
-
-		["GrpCSAT_MMG1", 2, "MMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_MMG2", 2, "MMG2", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_HMG1",  2, "HMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_MAT1", 3, "MAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_MAT2", 3, "MAT2", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_HAT1",  3, "HAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_MTR1",  5, "MTR1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_MSAM1",  3, "MSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_HSAM1",  3, "HSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_ST1",  4, "ST1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_DT1",  4, "DT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_ENG1",  6, "ENG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-
- 		["GrpCSAT_IFV1",  7, "IFV1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_IFV2",  7, "IFV2", "ColorOrange"] spawn f_fnc_localGroupMarker;
- 		["GrpCSAT_TNK1",  8, "TNK1", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["GrpCSAT_TH1",  9, "TH1", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_TH2",  9, "TH2", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_TH3",  9, "TH3", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_TH4",  9, "TH4", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_TH5",  9, "TH5", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_TH6",  9, "TH6", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_TH7",  9, "TH7", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpCSAT_TH8",  9, "TH8", "ColorOrange"] spawn f_fnc_localGroupMarker;
-
-		["GrpCSAT_AH1",  9, "AH1", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["UnitCSAT_CO_M", 0, "COM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitCSAT_DC_M", 0, "DCM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitCSAT_ASL_M", 0, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitCSAT_BSL_M", 0, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitCSAT_CSL_M", 0, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-	};
-
+#include "f_setLocalGroupMarkers_Blufor.sqf"
 
 // ====================================================================================
 
-// MARKERS: INDEPEDENT > AAF
-// Markers seen by players in AAF slots.
+// MARKERS: OPFOR
+// Markers seen by players in OPFOR slots
 
-	case "ind_f":
-	{
-		["GrpAAF_CO", 0, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_DC", 0, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_COV", 7, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
-
-		["GrpAAF_ASL", 0, "ASL", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_A1", 1, "A1", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_A2", 1, "A2", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_AV", 7, "AV", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["GrpAAF_BSL", 0, "BSL", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_B1", 1, "B1", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_B2", 1, "B2", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_BV", 7, "BV", "ColorBlue"] spawn f_fnc_localGroupMarker;
-
-		["GrpAAF_CSL", 0, "CSL", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_C1", 1, "C1", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_C2", 1, "C2", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_CV", 7, "CV", "ColorGreen"] spawn f_fnc_localGroupMarker;
-
-		["GrpAAF_JSL", 0, "JSL", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_J1", 1, "J1", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_J2", 1, "J2", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_JV", 7, "JV", "ColorPink"] spawn f_fnc_localGroupMarker;
-
-		["GrpAAF_MMG1", 2, "MMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_MMG2", 2, "MMG2", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_HMG1",  2, "HMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_MAT1", 3, "MAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_MAT2", 3, "MAT2", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_HAT1",  3, "HAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_MTR1",  5, "MTR1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_MSAM1",  3, "MSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_HSAM1",  3, "HSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_ST1",  4, "ST1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_DT1",  4, "DT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_ENG1",  6, "ENG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-
- 		["GrpAAF_IFV1",  7, "IFV1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_IFV2",  7, "IFV2", "ColorOrange"] spawn f_fnc_localGroupMarker;
- 		["GrpAAF_TNK1",  8, "TNK1", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["GrpAAF_TH1",  9, "TH1", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_TH2",  9, "TH2", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_TH3",  9, "TH3", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpAAF_TH4",  9, "TH4", "ColorOrange"] spawn f_fnc_localGroupMarker;
-
-		["GrpAAF_AH1",  9, "AH1", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["UnitAAF_CO_M", 0, "COM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitAAF_DC_M", 0, "DCM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitAAF_ASL_M", 0, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitAAF_BSL_M", 0, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitAAF_CSL_M", 0, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-	};
-// ====================================================================================
-
-// MARKERS: BLUFOR > FIA
-// Markers seen by players in BLUFOR-FIA slots.
-
-	case "blu_g_f":
-	{
-		["GrpFIA_CO", 0, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_DC", 0, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_COV", 7, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
-
-		["GrpFIA_ASL", 0, "ASL", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_A1", 1, "A1", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_A2", 1, "A2", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_AV", 7, "AV", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["GrpFIA_BSL", 0, "BSL", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_B1", 1, "B1", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_B2", 1, "B2", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_BV", 7, "BV", "ColorBlue"] spawn f_fnc_localGroupMarker;
-
-		["GrpFIA_CSL", 0, "CSL", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_C1", 1, "C1", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_C2", 1, "C2", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_CV", 7, "CV", "ColorGreen"] spawn f_fnc_localGroupMarker;
-
-		["GrpFIA_JSL", 0, "JSL", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_J1", 1, "J1", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_J2", 1, "J2", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_JV", 7, "JV", "ColorPink"] spawn f_fnc_localGroupMarker;
-
-		["GrpFIA_MMG1", 2, "MMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_MMG2", 2, "MMG2", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_HMG1",  2, "HMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_MAT1", 3, "MAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_MAT2", 3, "MAT2", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_HAT1",  3, "HAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_MTR1",  5, "MTR1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_MSAM1",  3, "MSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_HSAM1",  3, "HSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_ST1",  4, "ST1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_DT1",  4, "DT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_ENG1",  6, "ENG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-
- 		["GrpFIA_IFV1",  7, "TECH1", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_IFV2",  7, "TECH2", "ColorRed"] spawn f_fnc_localGroupMarker;
- 		["GrpFIA_TNK1",  8, "TNK1", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["GrpFIA_TH1",  9, "TH1", "ColorRed"] spawn f_fnc_localGroupMarker;
- 		["GrpFIA_TH2",  9, "TH2", "ColorRed"] spawn f_fnc_localGroupMarker;
- 		["GrpFIA_TH3",  9, "TH3", "ColorBlue"] spawn f_fnc_localGroupMarker;
- 		["GrpFIA_TH4",  9, "TH4", "ColorBlue"] spawn f_fnc_localGroupMarker;
- 		["GrpFIA_TH5",  9, "TH5", "ColorGreen"] spawn f_fnc_localGroupMarker;
-  		["GrpFIA_TH6",  9, "TH6", "ColorGreen"] spawn f_fnc_localGroupMarker;
-   		["GrpFIA_TH7",  9, "TH7", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpFIA_TH8",  9, "TH8", "ColorOrange"] spawn f_fnc_localGroupMarker;
-
-		["GrpFIA_AH1",  9, "AH1", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["UnitFIA_CO_M", 0, "COM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitFIA_DC_M", 0, "DCM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitFIA_ASL_M", 0, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitFIA_BSL_M", 0, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitFIA_CSL_M", 0, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-
-	};
+#include "f_setLocalGroupMarkers_Opfor.sqf"
 
 // ====================================================================================
 
-// MARKERS: OPFOR > FIA
-// Markers seen by players in OPFOR-FIA slots.
+// MARKERS: INDFOR
+// Markers seen by players in INDEPENDENT slots
 
-	case "opf_g_f":
-	{
-		["GrpOFIA_CO", 0, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_DC", 0, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_COV", 7, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
-
-		["GrpOFIA_ASL", 0, "ASL", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_A1", 1, "A1", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_A2", 1, "A2", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_AV", 7, "AV", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["GrpOFIA_BSL", 0, "BSL", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_B1", 1, "B1", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_B2", 1, "B2", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_BV", 7, "BV", "ColorBlue"] spawn f_fnc_localGroupMarker;
-
-		["GrpOFIA_CSL", 0, "CSL", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_C1", 1, "C1", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_C2", 1, "C2", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_CV", 7, "CV", "ColorGreen"] spawn f_fnc_localGroupMarker;
-
-		["GrpOFIA_JSL", 0, "JSL", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_J1", 1, "J1", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_J2", 1, "J2", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_JV", 7, "JV", "ColorPink"] spawn f_fnc_localGroupMarker;
-
-		["GrpOFIA_MMG1", 2, "MMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_MMG2", 2, "MMG2", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_HMG1",  2, "HMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_MAT1", 3, "MAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_MAT2", 3, "MAT2", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_HAT1",  3, "HAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_MTR1",  5, "MTR1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_MSAM1",  3, "MSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_HSAM1",  3, "HSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_ST1",  4, "ST1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_DT1",  4, "DT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_ENG1",  6, "ENG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-
- 		["GrpOFIA_IFV1",  7, "TECH1", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_IFV2",  7, "TECH2", "ColorRed"] spawn f_fnc_localGroupMarker;
- 		["GrpOFIA_TNK1",  8, "TNK1", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["GrpOFIA_TH1",  9, "TH1", "ColorRed"] spawn f_fnc_localGroupMarker;
- 		["GrpOFIA_TH2",  9, "TH2", "ColorRed"] spawn f_fnc_localGroupMarker;
- 		["GrpOFIA_TH3",  9, "TH3", "ColorBlue"] spawn f_fnc_localGroupMarker;
- 		["GrpOFIA_TH4",  9, "TH4", "ColorBlue"] spawn f_fnc_localGroupMarker;
- 		["GrpOFIA_TH5",  9, "TH5", "ColorGreen"] spawn f_fnc_localGroupMarker;
-  		["GrpOFIA_TH6",  9, "TH6", "ColorGreen"] spawn f_fnc_localGroupMarker;
-   		["GrpOFIA_TH7",  9, "TH7", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpOFIA_TH8",  9, "TH8", "ColorOrange"] spawn f_fnc_localGroupMarker;
-
-		["GrpOFIA_AH1",  9, "AH1", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["UnitOFIA_CO_M", 0, "COM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitOFIA_DC_M", 0, "DCM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitOFIA_ASL_M", 0, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitOFIA_BSL_M", 0, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitOFIA_CSL_M", 0, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-
-	};
+#include "f_setLocalGroupMarkers_Indfor.sqf"
 
 // ====================================================================================
-
-// MARKERS: INDEPENDENT > FIA
-// Markers seen by players in INDEPENDENT-FIA slots.
-
-	case "ind_g_f":
-	{
-		["GrpIFIA_CO", 0, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_DC", 0, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_COV", 7, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
-
-		["GrpIFIA_ASL", 0, "ASL", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_A1", 1, "A1", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_A2", 1, "A2", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_AV", 7, "AV", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["GrpIFIA_BSL", 0, "BSL", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_B1", 1, "B1", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_B2", 1, "B2", "ColorBlue"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_BV", 7, "BV", "ColorBlue"] spawn f_fnc_localGroupMarker;
-
-		["GrpIFIA_CSL", 0, "CSL", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_C1", 1, "C1", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_C2", 1, "C2", "ColorGreen"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_CV", 7, "CV", "ColorGreen"] spawn f_fnc_localGroupMarker;
-
-		["GrpIFIA_JSL", 0, "JSL", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_J1", 1, "J1", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_J2", 1, "J2", "ColorPink"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_JV", 7, "JV", "ColorPink"] spawn f_fnc_localGroupMarker;
-
-		["GrpIFIA_MMG1", 2, "MMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_MMG2", 2, "MMG2", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_HMG1",  2, "HMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_MAT1", 3, "MAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_MAT2", 3, "MAT2", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_HAT1",  3, "HAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_MTR1",  5, "MTR1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_MSAM1",  3, "MSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_HSAM1",  3, "HSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_ST1",  4, "ST1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_DT1",  4, "DT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_ENG1",  6, "ENG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
-
- 		["GrpIFIA_IFV1",  7, "TECH1", "ColorRed"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_IFV2",  7, "TECH2", "ColorRed"] spawn f_fnc_localGroupMarker;
- 		["GrpIFIA_TNK1",  8, "TNK1", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["GrpIFIA_TH1",  9, "TH1", "ColorRed"] spawn f_fnc_localGroupMarker;
- 		["GrpIFIA_TH2",  9, "TH2", "ColorRed"] spawn f_fnc_localGroupMarker;
- 		["GrpIFIA_TH3",  9, "TH3", "ColorBlue"] spawn f_fnc_localGroupMarker;
- 		["GrpIFIA_TH4",  9, "TH4", "ColorBlue"] spawn f_fnc_localGroupMarker;
- 		["GrpIFIA_TH5",  9, "TH5", "ColorGreen"] spawn f_fnc_localGroupMarker;
-  		["GrpIFIA_TH6",  9, "TH6", "ColorGreen"] spawn f_fnc_localGroupMarker;
-   		["GrpIFIA_TH7",  9, "TH7", "ColorOrange"] spawn f_fnc_localGroupMarker;
-		["GrpIFIA_TH8",  9, "TH8", "ColorOrange"] spawn f_fnc_localGroupMarker;
-
-		["GrpIFIA_AH1",  9, "AH1", "ColorRed"] spawn f_fnc_localGroupMarker;
-
-		["UnitIFIA_CO_M", 0, "COM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitIFIA_DC_M", 0, "DCM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitIFIA_ASL_M", 0, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitIFIA_BSL_M", 0, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-		["UnitIFIA_CSL_M", 0, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-
-	};
 
 };
-
-// ====================================================================================
-
-

--- a/f/groupMarkers/f_setLocalGroupMarkers_Blufor.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers_Blufor.sqf
@@ -1,0 +1,137 @@
+// F3 - Folk Group Markers - BLUFOR
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+// ====================================================================================
+
+// MARKERS: BLUFOR > NATO
+// Markers seen by players in NATO slots.
+
+case "blu_f":
+{
+	["GrpNATO_CO",_hq, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_DC",_hq, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_COV",_ifv, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
+
+	["GrpNATO_ASL",_hq, "ASL", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_A1",_ft, "A1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_A2",_ft, "A2", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_AV",_ifv, "AV", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["GrpNATO_BSL",_hq, "BSL", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_B1",_ft, "B1", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_B2",_ft, "B2", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_BV",_ifv, "BV", "ColorBlue"] spawn f_fnc_localGroupMarker;
+
+	["GrpNATO_CSL",_hq, "CSL", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_C1",_ft, "C1", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_C2",_ft, "C2", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_CV",_ifv, "CV", "ColorGreen"] spawn f_fnc_localGroupMarker;
+
+	["GrpNATO_JSL",_hq, "JSL", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_J1",_ft, "J1", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_J2",_ft, "J2", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_JV",_ifv, "JV", "ColorPink"] spawn f_fnc_localGroupMarker;
+
+	["GrpNATO_MMG1",_sup, "MMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_MMG2",_sup, "MMG2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_HMG1",_sup, "HMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_MAT1",_lau, "MAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_MAT2",_lau, "MAT2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_HAT1",_lau, "HAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_MTR1",_mor, "MTR1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_MSAM1",_lau, "MSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_HSAM1",_lau, "HSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_ST1",_rec, "ST1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_DT1",_rec, "DT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_ENG1",_eng, "ENG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+
+	["GrpNATO_IFV1",_ifv, "IFV1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_IFV2",_ifv, "IFV2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_TNK1",_tnk, "TNK1", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["GrpNATO_TH1",_hel, "TH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_TH2",_hel, "TH2", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_TH3",_hel, "TH3", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_TH4",_hel, "TH4", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_TH5",_hel, "TH5", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_TH6",_hel, "TH6", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_TH7",_hel, "TH7", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpNATO_TH8",_hel, "TH8", "ColorOrange"] spawn f_fnc_localGroupMarker;
+
+	["GrpNATO_AH1",_hel, "AH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["UnitNATO_CO_M",_med, "COM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitNATO_DC_M",_med, "DCM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitNATO_ASL_M",_med, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitNATO_BSL_M",_med, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitNATO_CSL_M",_med, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+
+};
+
+// ====================================================================================
+
+// MARKERS: BLUFOR > FIA
+// Markers seen by players in FIA slots.
+
+case "blu_g_f":
+{
+	["GrpFIA_CO",_hq, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_DC",_hq, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_COV",_ifv, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
+
+	["GrpFIA_ASL",_hq, "ASL", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_A1",_ft, "A1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_A2",_ft, "A2", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_AV",_ifv, "AV", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["GrpFIA_BSL",_hq, "BSL", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_B1",_ft, "B1", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_B2",_ft, "B2", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_BV",_ifv, "BV", "ColorBlue"] spawn f_fnc_localGroupMarker;
+
+	["GrpFIA_CSL",_hq, "CSL", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_C1",_ft, "C1", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_C2",_ft, "C2", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_CV",_ifv, "CV", "ColorGreen"] spawn f_fnc_localGroupMarker;
+
+	["GrpFIA_JSL",_hq, "JSL", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_J1",_ft, "J1", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_J2",_ft, "J2", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_JV",_ifv, "JV", "ColorPink"] spawn f_fnc_localGroupMarker;
+
+	["GrpFIA_MMG1",_sup, "MMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_MMG2",_sup, "MMG2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_HMG1",_sup, "HMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_MAT1",_lau, "MAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_MAT2",_lau, "MAT2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_HAT1",_lau, "HAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_MTR1",_mor, "MTR1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_MSAM1",_lau, "MSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_HSAM1",_lau, "HSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_ST1",_rec, "ST1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_DT1",_rec, "DT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_ENG1",_eng, "ENG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+
+	["GrpFIA_IFV1",_ifv, "TECH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_IFV2",_ifv, "TECH2", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_TNK1",_tnk, "TNK1", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["GrpFIA_TH1",_hel, "TH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_TH2",_hel, "TH2", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_TH3",_hel, "TH3", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_TH4",_hel, "TH4", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_TH5",_hel, "TH5", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_TH6",_hel, "TH6", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_TH7",_hel, "TH7", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpFIA_TH8",_hel, "TH8", "ColorOrange"] spawn f_fnc_localGroupMarker;
+
+	["GrpFIA_AH1",_hel, "AH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["UnitFIA_CO_M",_med, "COM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitFIA_DC_M",_med, "DCM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitFIA_ASL_M",_med, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitFIA_BSL_M",_med, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitFIA_CSL_M",_med, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+
+};
+
+// ====================================================================================

--- a/f/groupMarkers/f_setLocalGroupMarkers_Indfor.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers_Indfor.sqf
@@ -1,0 +1,132 @@
+// F3 - Folk Group Markers - INDFOR
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+// ====================================================================================
+
+// MARKERS: INDEPEDENT > AAF
+// Markers seen by players in AAF slots.
+
+case "ind_f":
+{
+	["GrpAAF_CO",_hq, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_DC",_hq, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_COV",_ifv, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
+
+	["GrpAAF_ASL",_hq, "ASL", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_A1",_ft, "A1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_A2",_ft, "A2", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_AV",_ifv, "AV", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["GrpAAF_BSL",_hq, "BSL", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_B1",_ft, "B1", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_B2",_ft, "B2", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_BV",_ifv, "BV", "ColorBlue"] spawn f_fnc_localGroupMarker;
+
+	["GrpAAF_CSL",_hq, "CSL", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_C1",_ft, "C1", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_C2",_ft, "C2", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_CV",_ifv, "CV", "ColorGreen"] spawn f_fnc_localGroupMarker;
+
+	["GrpAAF_JSL",_hq, "JSL", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_J1",_ft, "J1", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_J2",_ft, "J2", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_JV",_ifv, "JV", "ColorPink"] spawn f_fnc_localGroupMarker;
+
+	["GrpAAF_MMG1",_sup, "MMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_MMG2",_sup, "MMG2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_HMG1",_sup, "HMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_MAT1",_lau, "MAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_MAT2",_lau, "MAT2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_HAT1",_lau, "HAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_MTR1",_mor, "MTR1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_MSAM1",_lau, "MSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_HSAM1",_lau, "HSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_ST1",_rec, "ST1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_DT1",_rec, "DT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_ENG1",_eng, "ENG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+
+	["GrpAAF_IFV1",_ifv, "IFV1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_IFV2",_ifv, "IFV2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_TNK1",_tnk, "TNK1", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["GrpAAF_TH1",_hel, "TH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_TH2",_hel, "TH2", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_TH3",_hel, "TH3", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpAAF_TH4",_hel, "TH4", "ColorOrange"] spawn f_fnc_localGroupMarker;
+
+	["GrpAAF_AH1",_hel, "AH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["UnitAAF_CO_M",_med, "COM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitAAF_DC_M",_med, "DCM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitAAF_ASL_M",_med, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitAAF_BSL_M",_med, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitAAF_CSL_M",_med, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+};
+
+// ====================================================================================
+
+// MARKERS: INDEPENDENT > FIA
+// Markers seen by players in INDEPENDENT-FIA slots.
+
+case "ind_g_f":
+{
+	["GrpIFIA_CO",_hq, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_DC",_hq, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_COV",_ifv, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
+
+	["GrpIFIA_ASL",_hq, "ASL", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_A1",_ft, "A1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_A2",_ft, "A2", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_AV",_ifv, "AV", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["GrpIFIA_BSL",_hq, "BSL", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_B1",_ft, "B1", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_B2",_ft, "B2", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_BV",_ifv, "BV", "ColorBlue"] spawn f_fnc_localGroupMarker;
+
+	["GrpIFIA_CSL",_hq, "CSL", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_C1",_ft, "C1", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_C2",_ft, "C2", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_CV",_ifv, "CV", "ColorGreen"] spawn f_fnc_localGroupMarker;
+
+	["GrpIFIA_JSL",_hq, "JSL", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_J1",_ft, "J1", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_J2",_ft, "J2", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_JV",_ifv, "JV", "ColorPink"] spawn f_fnc_localGroupMarker;
+
+	["GrpIFIA_MMG1",_sup, "MMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_MMG2",_sup, "MMG2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_HMG1",_sup, "HMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_MAT1",_lau, "MAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_MAT2",_lau, "MAT2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_HAT1",_lau, "HAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_MTR1",_mor, "MTR1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_MSAM1",_lau, "MSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_HSAM1",_lau, "HSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_ST1",_rec, "ST1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_DT1",_rec, "DT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_ENG1",_eng, "ENG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+
+	["GrpIFIA_IFV1",_ifv, "TECH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_IFV2",_ifv, "TECH2", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_TNK1",_tnk, "TNK1", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["GrpIFIA_TH1",_hel, "TH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_TH2",_hel, "TH2", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_TH3",_hel, "TH3", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_TH4",_hel, "TH4", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_TH5",_hel, "TH5", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_TH6",_hel, "TH6", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_TH7",_hel, "TH7", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpIFIA_TH8",_hel, "TH8", "ColorOrange"] spawn f_fnc_localGroupMarker;
+
+	["GrpIFIA_AH1",_hel, "AH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["UnitIFIA_CO_M",_med, "COM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitIFIA_DC_M",_med, "DCM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitIFIA_ASL_M",_med, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitIFIA_BSL_M",_med, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitIFIA_CSL_M",_med, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+
+};
+
+// ====================================================================================

--- a/f/groupMarkers/f_setLocalGroupMarkers_Opfor.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers_Opfor.sqf
@@ -1,0 +1,136 @@
+// F3 - Folk Group Markers - OPFOR
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+// ====================================================================================
+
+// MARKERS: OPFOR > CSAT
+// Markers seen by players in CSAT slots.
+
+case "opf_f":
+{
+	["GrpCSAT_CO",_hq, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_DC",_hq, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_COV",_ifv, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
+
+	["GrpCSAT_ASL",_hq, "ASL", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_A1",_ft, "A1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_A2",_ft, "A2", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_AV",_ifv, "AV", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["GrpCSAT_BSL",_hq, "BSL", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_B1",_ft, "B1", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_B2",_ft, "B2", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_BV",_ifv, "BV", "ColorBlue"] spawn f_fnc_localGroupMarker;
+
+	["GrpCSAT_CSL",_hq, "CSL", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_C1",_ft, "C1", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_C2",_ft, "C2", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_CV",_ifv, "CV", "ColorGreen"] spawn f_fnc_localGroupMarker;
+
+	["GrpCSAT_JSL",_hq, "JSL", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_J1",_ft, "J1", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_J2",_ft, "J2", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_JV",_ifv, "JV", "ColorPink"] spawn f_fnc_localGroupMarker;
+
+	["GrpCSAT_MMG1",_sup, "MMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_MMG2",_sup, "MMG2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_HMG1",_sup, "HMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_MAT1",_lau, "MAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_MAT2",_lau, "MAT2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_HAT1",_lau, "HAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_MTR1",_mor, "MTR1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_MSAM1",_lau, "MSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_HSAM1",_lau, "HSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_ST1",_rec, "ST1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_DT1",_rec, "DT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_ENG1",_eng, "ENG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+
+	["GrpCSAT_IFV1",_ifv, "IFV1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_IFV2",_ifv, "IFV2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_TNK1",_tnk, "TNK1", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["GrpCSAT_TH1",_hel, "TH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_TH2",_hel, "TH2", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_TH3",_hel, "TH3", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_TH4",_hel, "TH4", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_TH5",_hel, "TH5", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_TH6",_hel, "TH6", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_TH7",_hel, "TH7", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpCSAT_TH8",_hel, "TH8", "ColorOrange"] spawn f_fnc_localGroupMarker;
+
+	["GrpCSAT_AH1",_hel, "AH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["UnitCSAT_CO_M",_med, "COM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitCSAT_DC_M",_med, "DCM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitCSAT_ASL_M",_med, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitCSAT_BSL_M",_med, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitCSAT_CSL_M",_med, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+};
+
+// ====================================================================================
+
+// MARKERS: OPFOR > FIA
+// Markers seen by players in OPFOR-FIA slots.
+
+case "opf_g_f":
+{
+	["GrpOFIA_CO",_hq, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_DC",_hq, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_COV",_ifv, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
+
+	["GrpOFIA_ASL",_hq, "ASL", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_A1",_ft, "A1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_A2",_ft, "A2", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_AV",_ifv, "AV", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["GrpOFIA_BSL",_hq, "BSL", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_B1",_ft, "B1", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_B2",_ft, "B2", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_BV",_ifv, "BV", "ColorBlue"] spawn f_fnc_localGroupMarker;
+
+	["GrpOFIA_CSL",_hq, "CSL", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_C1",_ft, "C1", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_C2",_ft, "C2", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_CV",_ifv, "CV", "ColorGreen"] spawn f_fnc_localGroupMarker;
+
+	["GrpOFIA_JSL",_hq, "JSL", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_J1",_ft, "J1", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_J2",_ft, "J2", "ColorPink"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_JV",_ifv, "JV", "ColorPink"] spawn f_fnc_localGroupMarker;
+
+	["GrpOFIA_MMG1",_sup, "MMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_MMG2",_sup, "MMG2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_HMG1",_sup, "HMG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_MAT1",_lau, "MAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_MAT2",_lau, "MAT2", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_HAT1",_lau, "HAT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_MTR1",_mor, "MTR1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_MSAM1",_lau, "MSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_HSAM1",_lau, "HSAM1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_ST1",_rec, "ST1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_DT1",_rec, "DT1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_ENG1",_eng, "ENG1", "ColorOrange"] spawn f_fnc_localGroupMarker;
+
+	["GrpOFIA_IFV1",_ifv, "TECH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_IFV2",_ifv, "TECH2", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_TNK1",_tnk, "TNK1", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["GrpOFIA_TH1",_hel, "TH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_TH2",_hel, "TH2", "ColorRed"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_TH3",_hel, "TH3", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_TH4",_hel, "TH4", "ColorBlue"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_TH5",_hel, "TH5", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_TH6",_hel, "TH6", "ColorGreen"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_TH7",_hel, "TH7", "ColorOrange"] spawn f_fnc_localGroupMarker;
+	["GrpOFIA_TH8",_hel, "TH8", "ColorOrange"] spawn f_fnc_localGroupMarker;
+
+	["GrpOFIA_AH1",_hel, "AH1", "ColorRed"] spawn f_fnc_localGroupMarker;
+
+	["UnitOFIA_CO_M",_med, "COM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitOFIA_DC_M",_med, "DCM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitOFIA_ASL_M",_med, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitOFIA_BSL_M",_med, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+	["UnitOFIA_CSL_M",_med, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
+
+};
+
+// ====================================================================================

--- a/f/groupMarkers/fn_localGroupMarker.sqf
+++ b/f/groupMarkers/fn_localGroupMarker.sqf
@@ -9,8 +9,7 @@
 // SET KEY VARIABLES
 // Using variables passed to the script instance, we will create some local variables:
 
-
-params["_grpName","_mkrType","_mkrText","_mkrColor"];
+params["_grpName",["_mkrType","b_hq"],"_mkrText",["_mkrColor","ColorBlack"]];
 
 private _grp = missionNamespace getVariable [_grpName,grpNull];
 private _mkrName = format ["mkr_%1",_grpName];
@@ -37,6 +36,14 @@ if (isnil "_grp") exitWith {};
 // CREATE MARKER
 // Depending on the value of _mkrType a different type of marker is created.
 
+_mkr = createMarkerLocal [_mkrName,[(getPos leader _grp select 0),(getPos leader _grp select 1)]];
+_mkr setMarkerShapeLocal "ICON";
+_mkrName setMarkerTypeLocal  _mkrType;
+_mkrName setMarkerColorLocal _mkrColor;
+_mkrName setMarkerSizeLocal [0.8, 0.8];
+_mkrName setMarkerTextLocal _mkrText;
+
+/*
 switch (_mkrType) do
 {
 
@@ -161,6 +168,7 @@ switch (_mkrType) do
 		_mkrName setMarkerTextLocal _mkrText;
 	};
 };
+*/
 
 // ====================================================================================
 

--- a/f/groupMarkers/fn_localSpecialistMarker.sqf
+++ b/f/groupMarkers/fn_localSpecialistMarker.sqf
@@ -11,9 +11,8 @@ private ["_mkr"];
 // SET KEY VARIABLES
 // Using variables passed to the script instance, we will create some local variables:
 
+params["_untName",["_mkrType","b_hq"],"_mkrText",["_mkrColor","ColorBlack"]];
 
-
-params["_untName", "_mkrType", "_mkrText", "_mkrColor"];
 private _mkrName = format ["mkr_%1",_untName];
 private _unt = missionNamespace getVariable [_untName, objNull];
 
@@ -39,6 +38,14 @@ if (!alive _unt) exitWith {};
 // CREATE MARKER
 // Depending on the value of _mkrType a different type of marker is created.
 
+_mkr = createMarkerLocal [_mkrName,[(getPos _unt select 0),(getPos _unt select 1)]];
+_mkr setMarkerShapeLocal "ICON";
+_mkrName setMarkerTypeLocal  _mkrType;
+_mkrName setMarkerColorLocal _mkrColor;
+_mkrName setMarkerSizeLocal [0.8, 0.8];
+_mkrName setMarkerTextLocal _mkrText;
+
+/*
 switch (_mkrType) do
 {
 
@@ -64,6 +71,7 @@ switch (_mkrType) do
 	};
 
 };
+*/
 
 // ====================================================================================
 

--- a/f/setAISkill/fn_setAISkill.sqf
+++ b/f/setAISkill/fn_setAISkill.sqf
@@ -20,7 +20,7 @@ _skillarray = _skillset; // If _skillset is not an array of skills, _skillarray 
 // FAULT CHECK
 // If f_setAISkill.sqf has not been run exit with an error message
 
-if ((isNil "f_var_skillSet") || (isNil "f_var_skillRandom")) exitWith {systemchat "F3 SetAISkill DBG: f_setAISkill.sqf needs to run before calling f_fnc_setAISkill!"};
+if ((isNil "f_var_skillSet") || (isNil "f_var_skillRandom")) exitWith {};
 
 // ====================================================================================
 

--- a/f/setGroupID/f_setGroupIDs.sqf
+++ b/f/setGroupID/f_setGroupIDs.sqf
@@ -1,3 +1,4 @@
+/*
 // F3 - Set Group IDs
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 // ====================================================================================

--- a/init.sqf
+++ b/init.sqf
@@ -33,10 +33,11 @@ f_script_briefing = [] execVM "briefing.sqf";
 
 // ====================================================================================
 
+// TODO REMOVE
 // F3 - F3 Folk ARPS Group IDs
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 
-f_script_setGroupIDs = [] execVM "f\setGroupID\f_setGroupIDs.sqf";
+// f_script_setGroupIDs = [] execVM "f\setGroupID\f_setGroupIDs.sqf";
 
 // ====================================================================================
 

--- a/mission.sqm
+++ b/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=1;
 	class ItemIDProvider
 	{
-		nextID=797;
+		nextID=823;
 	};
 	class Camera
 	{
@@ -47,7 +47,6 @@ addons[]=
 	"A3_Armor_F_Beta_APC_Wheeled_01",
 	"A3_Armor_F_Beta_APC_Tracked_02",
 	"A3_Armor_F_EPB_APC_Tracked_03",
-	"A3_Modules_F",
 	"A3_Modules_F_Curator_Curator",
 	"A3_Modules_F_Supports",
 	"A3_Characters_F",
@@ -145,15 +144,15 @@ class AddonsMetaData
 		};
 		class Item12
 		{
-			className="A3_Modules_F";
-			name="Arma 3 Alpha - Scripted Modules";
+			className="A3_Modules_F_Curator";
+			name="Arma 3 Zeus Update - Scripted features";
 			author="Bohemia Interactive";
 			url="http://www.arma3.com";
 		};
 		class Item13
 		{
-			className="A3_Modules_F_Curator";
-			name="Arma 3 Zeus Update - Scripted features";
+			className="A3_Modules_F";
+			name="Arma 3 Alpha - Scripted Modules";
 			author="Bohemia Interactive";
 			url="http://www.arma3.com";
 		};
@@ -240,7 +239,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=314;
+		items=298;
 		class Item0
 		{
 			dataType="Object";
@@ -1946,198 +1945,6 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={10658.214,22.488585,12673.875};
-			};
-			name="F3_preMount_AAF";
-			init="[synchronizedObjects this,[""GrpAAF_ASL"",""GrpAAF_A1"",""GrpAAF_A2"",""GrpAAF_A3""],true,false] call f_fnc_mountGroups;";
-			id=90;
-			type="Logic";
-		};
-		class Item91
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10387.935,13.960616,11953.215};
-			};
-			name="F3_preMount_NATO";
-			init="[synchronizedObjects this,[""GrpNATO_ASL"",""GrpNATO_A1"",""GrpNATO_A2"",""GrpNATO_A3""],true,false] call f_fnc_mountGroups;";
-			id=91;
-			type="Logic";
-		};
-		class Item92
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={11491.055,24.757618,11834.113};
-			};
-			name="F3_preMount_CSAT";
-			init="[synchronizedObjects this,[""GrpCSAT_ASL"",""GrpCSAT_A1"",""GrpCSAT_A2"",""GrpCSAT_A3""],true,false] call f_fnc_mountGroups;";
-			id=92;
-			type="Logic";
-		};
-		class Item93
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10610.131,6.2930422,11337.318};
-			};
-			name="F3_preMount_FIA";
-			init="[synchronizedObjects this,[""GrpFIA_ASL"",""GrpFIA_A1"",""GrpFIA_A2"",""GrpFIA_A3""],true,false] call f_fnc_mountGroups;";
-			id=93;
-			type="Logic";
-		};
-		class Item94
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={11512.367,24.328245,11833.844};
-			};
-			name="F3_preMount_CSAT_1";
-			init="[synchronizedObjects this,[""GrpCSAT_BSL"",""GrpCSAT_B1"",""GrpCSAT_B2"",""GrpCSAT_B3""],true,false] call f_fnc_mountGroups;";
-			id=94;
-			type="Logic";
-		};
-		class Item95
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={11539.048,23.283566,11832.836};
-			};
-			name="F3_preMount_CSAT_2";
-			init="[synchronizedObjects this,[""GrpCSAT_CSL"",""GrpCSAT_C1"",""GrpCSAT_C2"",""GrpCSAT_C3""],true,false] call f_fnc_mountGroups;";
-			id=95;
-			type="Logic";
-		};
-		class Item96
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={11464.67,25.111698,11832.838};
-			};
-			name="F3_preMount_CSAT_3";
-			init="[synchronizedObjects this,[""GrpCSAT_CO"",""GrpCSAT_DC""],true,false] call f_fnc_mountGroups;";
-			id=96;
-			type="Logic";
-		};
-		class Item97
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10415.253,13.868641,11953.383};
-			};
-			name="F3_preMount_NATO_1";
-			init="[synchronizedObjects this,[""GrpNATO_BSL"",""GrpNATO_B1"",""GrpNATO_B2"",""GrpNATO_B3""],true,false] call f_fnc_mountGroups;";
-			id=97;
-			type="Logic";
-		};
-		class Item98
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10437.017,13.975767,11953.541};
-			};
-			name="F3_preMount_NATO_2";
-			init="[synchronizedObjects this,[""GrpNATO_CSL"",""GrpNATO_C1"",""GrpNATO_C2"",""GrpNATO_C3""],true,false] call f_fnc_mountGroups;";
-			id=98;
-			type="Logic";
-		};
-		class Item99
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10363.6,12.996475,11952.816};
-			};
-			name="F3_preMount_NATO_3";
-			init="[synchronizedObjects this,[""GrpNATO_CO"",""GrpNATO_DC""],true,false] call f_fnc_mountGroups;";
-			id=99;
-			type="Logic";
-		};
-		class Item100
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10682.417,22.200792,12675.91};
-			};
-			name="F3_preMount_AAF_1";
-			init="[synchronizedObjects this,[""GrpAAF_BSL"",""GrpAAF_B1"",""GrpAAF_B2"",""GrpAAF_B3""],true,false] call f_fnc_mountGroups;";
-			id=100;
-			type="Logic";
-		};
-		class Item101
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10708.246,21.864967,12677.332};
-			};
-			name="F3_preMount_AAF_2";
-			init="[synchronizedObjects this,[""GrpAAF_CSL"",""GrpAAF_C1"",""GrpAAF_C2"",""GrpAAF_C3""],true,false] call f_fnc_mountGroups;";
-			id=101;
-			type="Logic";
-		};
-		class Item102
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10635.507,22.506218,12674.668};
-			};
-			name="F3_preMount_AAF_3";
-			init="[synchronizedObjects this,[""GrpAAF_CO"",""GrpAAF_DC""],true,false] call f_fnc_mountGroups;";
-			id=102;
-			type="Logic";
-		};
-		class Item103
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10636.474,7.4060206,11337.207};
-			};
-			name="F3_preMount_FIA_1";
-			init="[synchronizedObjects this,[""GrpFIA_BSL"",""GrpFIA_B1"",""GrpFIA_B2"",""GrpFIA_B3""],true,false] call f_fnc_mountGroups;";
-			id=103;
-			type="Logic";
-		};
-		class Item104
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10659.468,8.2664013,11339.884};
-			};
-			name="F3_preMount_FIA_2";
-			init="[synchronizedObjects this,[""GrpFIA_CSL"",""GrpFIA_C1"",""GrpFIA_C2"",""GrpFIA_C3""],true,false] call f_fnc_mountGroups;";
-			id=104;
-			type="Logic";
-		};
-		class Item105
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10587.584,6.1283669,11337.678};
-			};
-			name="F3_preMount_FIA_3";
-			init="[synchronizedObjects this,[""GrpFIA_CO"",""GrpFIA_DC""],true,false] call f_fnc_mountGroups;";
-			id=105;
-			type="Logic";
-		};
-		class Item106
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
 				position[]={10928.654,18.324749,12383.823};
 			};
 			init="this addEventHandler ['CuratorObjectPlaced',{{[_x] call f_fnc_setAISKill} forEach crew(_this select 1)}];this addCuratorEditableObjects [playableUnits,true];";
@@ -2243,7 +2050,7 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item107
+		class Item91
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -2353,7 +2160,7 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item108
+		class Item92
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -2463,7 +2270,7 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item109
+		class Item93
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -2573,7 +2380,7 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item110
+		class Item94
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -2720,27 +2527,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item111
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10342.236,12.939925,11916.079};
-			};
-			id=111;
-			type="SupportProvider_Artillery";
-		};
-		class Item112
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10346.518,13.330897,11915.982};
-			};
-			id=112;
-			type="SupportProvider_CAS_Heli";
-		};
-		class Item113
+		class Item95
 		{
 			dataType="Group";
 			side="West";
@@ -2792,7 +2579,7 @@ class Mission
 			id=113;
 			atlOffset=-9.5367432e-007;
 		};
-		class Item114
+		class Item96
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2810,7 +2597,7 @@ class Mission
 			type="B_Mortar_01_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item115
+		class Item97
 		{
 			dataType="Group";
 			side="West";
@@ -2887,7 +2674,7 @@ class Mission
 			};
 			id=116;
 		};
-		class Item116
+		class Item98
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2904,7 +2691,7 @@ class Mission
 			id=117;
 			type="B_Heli_Light_01_armed_F";
 		};
-		class Item117
+		class Item99
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3051,27 +2838,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item118
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10569.012,7.8425264,11308.867};
-			};
-			id=121;
-			type="SupportProvider_Artillery";
-		};
-		class Item119
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10573.293,7.7925463,11308.771};
-			};
-			id=122;
-			type="SupportProvider_CAS_Heli";
-		};
-		class Item120
+		class Item100
 		{
 			dataType="Group";
 			side="West";
@@ -3124,7 +2891,7 @@ class Mission
 			id=123;
 			atlOffset=4.7683716e-007;
 		};
-		class Item121
+		class Item101
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3142,7 +2909,7 @@ class Mission
 			type="B_Mortar_01_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item122
+		class Item102
 		{
 			dataType="Group";
 			side="West";
@@ -3221,7 +2988,7 @@ class Mission
 			id=126;
 			atlOffset=4.7683716e-007;
 		};
-		class Item123
+		class Item103
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3239,7 +3006,7 @@ class Mission
 			type="B_Heli_Light_01_armed_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item124
+		class Item104
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3386,27 +3153,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item125
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10569.258,7.155221,11291.229};
-			};
-			id=131;
-			type="SupportProvider_Artillery";
-		};
-		class Item126
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10573.539,7.0689368,11291.133};
-			};
-			id=132;
-			type="SupportProvider_CAS_Heli";
-		};
-		class Item127
+		class Item105
 		{
 			dataType="Group";
 			side="West";
@@ -3458,7 +3205,7 @@ class Mission
 			};
 			id=133;
 		};
-		class Item128
+		class Item106
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3475,7 +3222,7 @@ class Mission
 			id=134;
 			type="B_Mortar_01_F";
 		};
-		class Item129
+		class Item107
 		{
 			dataType="Group";
 			side="West";
@@ -3553,7 +3300,7 @@ class Mission
 			};
 			id=136;
 		};
-		class Item130
+		class Item108
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3570,7 +3317,7 @@ class Mission
 			id=137;
 			type="B_Heli_Light_01_armed_F";
 		};
-		class Item131
+		class Item109
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3717,27 +3464,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item132
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={11434.104,25.597261,11795.064};
-			};
-			id=141;
-			type="SupportProvider_Artillery";
-		};
-		class Item133
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={11438.386,25.360546,11794.968};
-			};
-			id=142;
-			type="SupportProvider_CAS_Heli";
-		};
-		class Item134
+		class Item110
 		{
 			dataType="Group";
 			side="East";
@@ -3815,7 +3542,7 @@ class Mission
 			id=143;
 			atlOffset=3.6239624e-005;
 		};
-		class Item135
+		class Item111
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3833,7 +3560,7 @@ class Mission
 			type="O_Heli_Light_02_v2_F";
 			atlOffset=3.6239624e-005;
 		};
-		class Item136
+		class Item112
 		{
 			dataType="Group";
 			side="East";
@@ -3884,7 +3611,7 @@ class Mission
 			};
 			id=147;
 		};
-		class Item137
+		class Item113
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3901,7 +3628,7 @@ class Mission
 			id=148;
 			type="O_Mortar_01_F";
 		};
-		class Item138
+		class Item114
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -4048,27 +3775,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item139
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={11434.053,25.027555,11778.637};
-			};
-			id=151;
-			type="SupportProvider_Artillery";
-		};
-		class Item140
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={11438.334,24.859396,11778.54};
-			};
-			id=152;
-			type="SupportProvider_CAS_Heli";
-		};
-		class Item141
+		class Item115
 		{
 			dataType="Group";
 			side="East";
@@ -4146,7 +3853,7 @@ class Mission
 			id=153;
 			atlOffset=-0.0009021759;
 		};
-		class Item142
+		class Item116
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4164,7 +3871,7 @@ class Mission
 			type="O_Heli_Light_02_v2_F";
 			atlOffset=-0.0009021759;
 		};
-		class Item143
+		class Item117
 		{
 			dataType="Group";
 			side="East";
@@ -4215,7 +3922,7 @@ class Mission
 			};
 			id=157;
 		};
-		class Item144
+		class Item118
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4232,7 +3939,7 @@ class Mission
 			id=158;
 			type="O_Mortar_01_F";
 		};
-		class Item145
+		class Item119
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -4379,27 +4086,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item146
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10605.599,20.064135,12643.422};
-			};
-			id=161;
-			type="SupportProvider_Artillery";
-		};
-		class Item147
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10609.88,20.189512,12643.325};
-			};
-			id=162;
-			type="SupportProvider_CAS_Heli";
-		};
-		class Item148
+		class Item120
 		{
 			dataType="Group";
 			side="Independent";
@@ -4476,7 +4163,7 @@ class Mission
 			};
 			id=163;
 		};
-		class Item149
+		class Item121
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4493,7 +4180,7 @@ class Mission
 			id=164;
 			type="I_Heli_light_03_F";
 		};
-		class Item150
+		class Item122
 		{
 			dataType="Group";
 			side="Independent";
@@ -4544,7 +4231,7 @@ class Mission
 			};
 			id=167;
 		};
-		class Item151
+		class Item123
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4561,7 +4248,7 @@ class Mission
 			id=168;
 			type="I_Mortar_01_F";
 		};
-		class Item152
+		class Item124
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -4708,27 +4395,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item153
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10605.6,19.375135,12627.477};
-			};
-			id=171;
-			type="SupportProvider_Artillery";
-		};
-		class Item154
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10609.881,19.35586,12627.38};
-			};
-			id=172;
-			type="SupportProvider_CAS_Heli";
-		};
-		class Item155
+		class Item125
 		{
 			dataType="Group";
 			side="Independent";
@@ -4805,7 +4472,7 @@ class Mission
 			};
 			id=173;
 		};
-		class Item156
+		class Item126
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4822,7 +4489,7 @@ class Mission
 			id=174;
 			type="I_Heli_light_03_F";
 		};
-		class Item157
+		class Item127
 		{
 			dataType="Group";
 			side="Independent";
@@ -4873,7 +4540,7 @@ class Mission
 			};
 			id=177;
 		};
-		class Item158
+		class Item128
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4890,7 +4557,7 @@ class Mission
 			id=178;
 			type="I_Mortar_01_F";
 		};
-		class Item159
+		class Item129
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5037,27 +4704,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item160
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10342.631,12.987046,11899.947};
-			};
-			id=181;
-			type="SupportProvider_Artillery";
-		};
-		class Item161
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={10346.912,12.932245,11899.851};
-			};
-			id=182;
-			type="SupportProvider_CAS_Heli";
-		};
-		class Item162
+		class Item130
 		{
 			dataType="Group";
 			side="West";
@@ -5108,7 +4755,7 @@ class Mission
 			};
 			id=183;
 		};
-		class Item163
+		class Item131
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5125,7 +4772,7 @@ class Mission
 			id=184;
 			type="B_Mortar_01_F";
 		};
-		class Item164
+		class Item132
 		{
 			dataType="Group";
 			side="West";
@@ -5202,7 +4849,7 @@ class Mission
 			};
 			id=186;
 		};
-		class Item165
+		class Item133
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5219,7 +4866,7 @@ class Mission
 			id=187;
 			type="B_Heli_Light_01_armed_F";
 		};
-		class Item166
+		class Item134
 		{
 			dataType="Group";
 			side="West";
@@ -5319,7 +4966,7 @@ class Mission
 			};
 			id=190;
 		};
-		class Item167
+		class Item135
 		{
 			dataType="Group";
 			side="West";
@@ -5420,7 +5067,7 @@ class Mission
 			};
 			id=195;
 		};
-		class Item168
+		class Item136
 		{
 			dataType="Group";
 			side="West";
@@ -5500,7 +5147,7 @@ class Mission
 			id=200;
 			atlOffset=-6.7710876e-005;
 		};
-		class Item169
+		class Item137
 		{
 			dataType="Group";
 			side="West";
@@ -5556,7 +5203,7 @@ class Mission
 			};
 			id=204;
 		};
-		class Item170
+		class Item138
 		{
 			dataType="Group";
 			side="West";
@@ -5696,7 +5343,7 @@ class Mission
 			};
 			id=207;
 		};
-		class Item171
+		class Item139
 		{
 			dataType="Group";
 			side="West";
@@ -5836,7 +5483,7 @@ class Mission
 			};
 			id=214;
 		};
-		class Item172
+		class Item140
 		{
 			dataType="Group";
 			side="West";
@@ -5914,7 +5561,7 @@ class Mission
 			};
 			id=221;
 		};
-		class Item173
+		class Item141
 		{
 			dataType="Group";
 			side="West";
@@ -5970,7 +5617,7 @@ class Mission
 			};
 			id=225;
 		};
-		class Item174
+		class Item142
 		{
 			dataType="Group";
 			side="West";
@@ -6110,7 +5757,7 @@ class Mission
 			};
 			id=228;
 		};
-		class Item175
+		class Item143
 		{
 			dataType="Group";
 			side="West";
@@ -6251,7 +5898,7 @@ class Mission
 			};
 			id=235;
 		};
-		class Item176
+		class Item144
 		{
 			dataType="Group";
 			side="West";
@@ -6329,7 +5976,7 @@ class Mission
 			};
 			id=242;
 		};
-		class Item177
+		class Item145
 		{
 			dataType="Group";
 			side="West";
@@ -6385,7 +6032,7 @@ class Mission
 			};
 			id=246;
 		};
-		class Item178
+		class Item146
 		{
 			dataType="Group";
 			side="West";
@@ -6525,7 +6172,7 @@ class Mission
 			};
 			id=249;
 		};
-		class Item179
+		class Item147
 		{
 			dataType="Group";
 			side="West";
@@ -6666,7 +6313,7 @@ class Mission
 			};
 			id=256;
 		};
-		class Item180
+		class Item148
 		{
 			dataType="Group";
 			side="West";
@@ -6744,7 +6391,7 @@ class Mission
 			};
 			id=263;
 		};
-		class Item181
+		class Item149
 		{
 			dataType="Group";
 			side="West";
@@ -6800,7 +6447,7 @@ class Mission
 			};
 			id=267;
 		};
-		class Item182
+		class Item150
 		{
 			dataType="Group";
 			side="West";
@@ -6856,7 +6503,7 @@ class Mission
 			};
 			id=270;
 		};
-		class Item183
+		class Item151
 		{
 			dataType="Group";
 			side="West";
@@ -6914,7 +6561,7 @@ class Mission
 			id=273;
 			atlOffset=-9.5367432e-007;
 		};
-		class Item184
+		class Item152
 		{
 			dataType="Group";
 			side="West";
@@ -6971,7 +6618,7 @@ class Mission
 			};
 			id=276;
 		};
-		class Item185
+		class Item153
 		{
 			dataType="Group";
 			side="West";
@@ -7027,7 +6674,7 @@ class Mission
 			};
 			id=279;
 		};
-		class Item186
+		class Item154
 		{
 			dataType="Group";
 			side="West";
@@ -7084,7 +6731,7 @@ class Mission
 			};
 			id=282;
 		};
-		class Item187
+		class Item155
 		{
 			dataType="Group";
 			side="West";
@@ -7141,7 +6788,7 @@ class Mission
 			};
 			id=285;
 		};
-		class Item188
+		class Item156
 		{
 			dataType="Group";
 			side="West";
@@ -7198,7 +6845,7 @@ class Mission
 			};
 			id=288;
 		};
-		class Item189
+		class Item157
 		{
 			dataType="Group";
 			side="West";
@@ -7255,7 +6902,7 @@ class Mission
 			};
 			id=291;
 		};
-		class Item190
+		class Item158
 		{
 			dataType="Group";
 			side="West";
@@ -7312,7 +6959,7 @@ class Mission
 			};
 			id=294;
 		};
-		class Item191
+		class Item159
 		{
 			dataType="Group";
 			side="West";
@@ -7410,7 +7057,7 @@ class Mission
 			};
 			id=297;
 		};
-		class Item192
+		class Item160
 		{
 			dataType="Group";
 			side="West";
@@ -7511,7 +7158,7 @@ class Mission
 			};
 			id=302;
 		};
-		class Item193
+		class Item161
 		{
 			dataType="Group";
 			side="West";
@@ -7590,7 +7237,7 @@ class Mission
 			};
 			id=307;
 		};
-		class Item194
+		class Item162
 		{
 			dataType="Group";
 			side="West";
@@ -7668,7 +7315,7 @@ class Mission
 			};
 			id=311;
 		};
-		class Item195
+		class Item163
 		{
 			dataType="Group";
 			side="West";
@@ -7746,7 +7393,7 @@ class Mission
 			};
 			id=315;
 		};
-		class Item196
+		class Item164
 		{
 			dataType="Group";
 			side="West";
@@ -7847,7 +7494,7 @@ class Mission
 			};
 			id=319;
 		};
-		class Item197
+		class Item165
 		{
 			dataType="Group";
 			side="West";
@@ -7948,7 +7595,7 @@ class Mission
 			};
 			id=324;
 		};
-		class Item198
+		class Item166
 		{
 			dataType="Group";
 			side="West";
@@ -8049,7 +7696,7 @@ class Mission
 			};
 			id=329;
 		};
-		class Item199
+		class Item167
 		{
 			dataType="Group";
 			side="West";
@@ -8150,7 +7797,7 @@ class Mission
 			};
 			id=334;
 		};
-		class Item200
+		class Item168
 		{
 			dataType="Group";
 			side="West";
@@ -8251,7 +7898,7 @@ class Mission
 			};
 			id=339;
 		};
-		class Item201
+		class Item169
 		{
 			dataType="Group";
 			side="West";
@@ -8352,7 +7999,7 @@ class Mission
 			};
 			id=344;
 		};
-		class Item202
+		class Item170
 		{
 			dataType="Group";
 			side="West";
@@ -8453,7 +8100,7 @@ class Mission
 			};
 			id=349;
 		};
-		class Item203
+		class Item171
 		{
 			dataType="Group";
 			side="West";
@@ -8555,7 +8202,7 @@ class Mission
 			};
 			id=354;
 		};
-		class Item204
+		class Item172
 		{
 			dataType="Group";
 			side="West";
@@ -8612,7 +8259,7 @@ class Mission
 			};
 			id=359;
 		};
-		class Item205
+		class Item173
 		{
 			dataType="Group";
 			side="West";
@@ -8705,7 +8352,7 @@ class Mission
 			};
 			id=362;
 		};
-		class Item206
+		class Item174
 		{
 			dataType="Group";
 			side="East";
@@ -8806,7 +8453,7 @@ class Mission
 			};
 			id=367;
 		};
-		class Item207
+		class Item175
 		{
 			dataType="Group";
 			side="East";
@@ -8908,7 +8555,7 @@ class Mission
 			};
 			id=372;
 		};
-		class Item208
+		class Item176
 		{
 			dataType="Group";
 			side="East";
@@ -8986,7 +8633,7 @@ class Mission
 			};
 			id=377;
 		};
-		class Item209
+		class Item177
 		{
 			dataType="Group";
 			side="East";
@@ -9044,7 +8691,7 @@ class Mission
 			};
 			id=381;
 		};
-		class Item210
+		class Item178
 		{
 			dataType="Group";
 			side="East";
@@ -9190,7 +8837,7 @@ class Mission
 			};
 			id=384;
 		};
-		class Item211
+		class Item179
 		{
 			dataType="Group";
 			side="East";
@@ -9336,7 +8983,7 @@ class Mission
 			};
 			id=391;
 		};
-		class Item212
+		class Item180
 		{
 			dataType="Group";
 			side="East";
@@ -9414,7 +9061,7 @@ class Mission
 			};
 			id=398;
 		};
-		class Item213
+		class Item181
 		{
 			dataType="Group";
 			side="East";
@@ -9472,7 +9119,7 @@ class Mission
 			};
 			id=402;
 		};
-		class Item214
+		class Item182
 		{
 			dataType="Group";
 			side="East";
@@ -9618,7 +9265,7 @@ class Mission
 			};
 			id=405;
 		};
-		class Item215
+		class Item183
 		{
 			dataType="Group";
 			side="East";
@@ -9764,7 +9411,7 @@ class Mission
 			};
 			id=412;
 		};
-		class Item216
+		class Item184
 		{
 			dataType="Group";
 			side="East";
@@ -9842,7 +9489,7 @@ class Mission
 			};
 			id=419;
 		};
-		class Item217
+		class Item185
 		{
 			dataType="Group";
 			side="East";
@@ -9900,7 +9547,7 @@ class Mission
 			};
 			id=423;
 		};
-		class Item218
+		class Item186
 		{
 			dataType="Group";
 			side="East";
@@ -10046,7 +9693,7 @@ class Mission
 			};
 			id=426;
 		};
-		class Item219
+		class Item187
 		{
 			dataType="Group";
 			side="East";
@@ -10192,7 +9839,7 @@ class Mission
 			};
 			id=433;
 		};
-		class Item220
+		class Item188
 		{
 			dataType="Group";
 			side="East";
@@ -10270,7 +9917,7 @@ class Mission
 			};
 			id=440;
 		};
-		class Item221
+		class Item189
 		{
 			dataType="Group";
 			side="East";
@@ -10328,7 +9975,7 @@ class Mission
 			};
 			id=444;
 		};
-		class Item222
+		class Item190
 		{
 			dataType="Group";
 			side="East";
@@ -10386,7 +10033,7 @@ class Mission
 			};
 			id=447;
 		};
-		class Item223
+		class Item191
 		{
 			dataType="Group";
 			side="East";
@@ -10441,7 +10088,7 @@ class Mission
 			};
 			id=450;
 		};
-		class Item224
+		class Item192
 		{
 			dataType="Group";
 			side="East";
@@ -10497,7 +10144,7 @@ class Mission
 			};
 			id=453;
 		};
-		class Item225
+		class Item193
 		{
 			dataType="Group";
 			side="East";
@@ -10553,7 +10200,7 @@ class Mission
 			};
 			id=456;
 		};
-		class Item226
+		class Item194
 		{
 			dataType="Group";
 			side="East";
@@ -10609,7 +10256,7 @@ class Mission
 			};
 			id=459;
 		};
-		class Item227
+		class Item195
 		{
 			dataType="Group";
 			side="East";
@@ -10665,7 +10312,7 @@ class Mission
 			};
 			id=462;
 		};
-		class Item228
+		class Item196
 		{
 			dataType="Group";
 			side="East";
@@ -10721,7 +10368,7 @@ class Mission
 			};
 			id=465;
 		};
-		class Item229
+		class Item197
 		{
 			dataType="Group";
 			side="East";
@@ -10778,7 +10425,7 @@ class Mission
 			};
 			id=468;
 		};
-		class Item230
+		class Item198
 		{
 			dataType="Group";
 			side="East";
@@ -10834,7 +10481,7 @@ class Mission
 			};
 			id=471;
 		};
-		class Item231
+		class Item199
 		{
 			dataType="Group";
 			side="East";
@@ -10932,7 +10579,7 @@ class Mission
 			};
 			id=474;
 		};
-		class Item232
+		class Item200
 		{
 			dataType="Group";
 			side="East";
@@ -11033,7 +10680,7 @@ class Mission
 			};
 			id=479;
 		};
-		class Item233
+		class Item201
 		{
 			dataType="Group";
 			side="East";
@@ -11111,7 +10758,7 @@ class Mission
 			};
 			id=484;
 		};
-		class Item234
+		class Item202
 		{
 			dataType="Group";
 			side="East";
@@ -11189,7 +10836,7 @@ class Mission
 			};
 			id=488;
 		};
-		class Item235
+		class Item203
 		{
 			dataType="Group";
 			side="East";
@@ -11267,7 +10914,7 @@ class Mission
 			};
 			id=492;
 		};
-		class Item236
+		class Item204
 		{
 			dataType="Group";
 			side="East";
@@ -11369,7 +11016,7 @@ class Mission
 			};
 			id=496;
 		};
-		class Item237
+		class Item205
 		{
 			dataType="Group";
 			side="East";
@@ -11448,7 +11095,7 @@ class Mission
 			};
 			id=500;
 		};
-		class Item238
+		class Item206
 		{
 			dataType="Group";
 			side="East";
@@ -11505,7 +11152,7 @@ class Mission
 			};
 			id=504;
 		};
-		class Item239
+		class Item207
 		{
 			dataType="Group";
 			side="East";
@@ -11562,7 +11209,7 @@ class Mission
 			};
 			id=507;
 		};
-		class Item240
+		class Item208
 		{
 			dataType="Group";
 			side="East";
@@ -11619,7 +11266,7 @@ class Mission
 			};
 			id=510;
 		};
-		class Item241
+		class Item209
 		{
 			dataType="Group";
 			side="East";
@@ -11676,7 +11323,7 @@ class Mission
 			};
 			id=513;
 		};
-		class Item242
+		class Item210
 		{
 			dataType="Group";
 			side="East";
@@ -11733,7 +11380,7 @@ class Mission
 			};
 			id=516;
 		};
-		class Item243
+		class Item211
 		{
 			dataType="Group";
 			side="East";
@@ -11790,7 +11437,7 @@ class Mission
 			};
 			id=519;
 		};
-		class Item244
+		class Item212
 		{
 			dataType="Group";
 			side="East";
@@ -11847,7 +11494,7 @@ class Mission
 			};
 			id=522;
 		};
-		class Item245
+		class Item213
 		{
 			dataType="Group";
 			side="East";
@@ -11940,7 +11587,7 @@ class Mission
 			};
 			id=525;
 		};
-		class Item246
+		class Item214
 		{
 			dataType="Group";
 			side="Independent";
@@ -12038,7 +11685,7 @@ class Mission
 			};
 			id=530;
 		};
-		class Item247
+		class Item215
 		{
 			dataType="Group";
 			side="Independent";
@@ -12136,7 +11783,7 @@ class Mission
 			};
 			id=535;
 		};
-		class Item248
+		class Item216
 		{
 			dataType="Group";
 			side="Independent";
@@ -12214,7 +11861,7 @@ class Mission
 			};
 			id=540;
 		};
-		class Item249
+		class Item217
 		{
 			dataType="Group";
 			side="Independent";
@@ -12270,7 +11917,7 @@ class Mission
 			};
 			id=544;
 		};
-		class Item250
+		class Item218
 		{
 			dataType="Group";
 			side="Independent";
@@ -12410,7 +12057,7 @@ class Mission
 			};
 			id=547;
 		};
-		class Item251
+		class Item219
 		{
 			dataType="Group";
 			side="Independent";
@@ -12550,7 +12197,7 @@ class Mission
 			};
 			id=554;
 		};
-		class Item252
+		class Item220
 		{
 			dataType="Group";
 			side="Independent";
@@ -12628,7 +12275,7 @@ class Mission
 			};
 			id=561;
 		};
-		class Item253
+		class Item221
 		{
 			dataType="Group";
 			side="Independent";
@@ -12684,7 +12331,7 @@ class Mission
 			};
 			id=565;
 		};
-		class Item254
+		class Item222
 		{
 			dataType="Group";
 			side="Independent";
@@ -12824,7 +12471,7 @@ class Mission
 			};
 			id=568;
 		};
-		class Item255
+		class Item223
 		{
 			dataType="Group";
 			side="Independent";
@@ -12966,7 +12613,7 @@ class Mission
 			};
 			id=575;
 		};
-		class Item256
+		class Item224
 		{
 			dataType="Group";
 			side="Independent";
@@ -13044,7 +12691,7 @@ class Mission
 			};
 			id=582;
 		};
-		class Item257
+		class Item225
 		{
 			dataType="Group";
 			side="Independent";
@@ -13100,7 +12747,7 @@ class Mission
 			};
 			id=586;
 		};
-		class Item258
+		class Item226
 		{
 			dataType="Group";
 			side="Independent";
@@ -13240,7 +12887,7 @@ class Mission
 			};
 			id=589;
 		};
-		class Item259
+		class Item227
 		{
 			dataType="Group";
 			side="Independent";
@@ -13382,7 +13029,7 @@ class Mission
 			};
 			id=596;
 		};
-		class Item260
+		class Item228
 		{
 			dataType="Group";
 			side="Independent";
@@ -13460,7 +13107,7 @@ class Mission
 			};
 			id=603;
 		};
-		class Item261
+		class Item229
 		{
 			dataType="Group";
 			side="Independent";
@@ -13516,7 +13163,7 @@ class Mission
 			};
 			id=607;
 		};
-		class Item262
+		class Item230
 		{
 			dataType="Group";
 			side="Independent";
@@ -13572,7 +13219,7 @@ class Mission
 			};
 			id=610;
 		};
-		class Item263
+		class Item231
 		{
 			dataType="Group";
 			side="Independent";
@@ -13628,7 +13275,7 @@ class Mission
 			};
 			id=613;
 		};
-		class Item264
+		class Item232
 		{
 			dataType="Group";
 			side="Independent";
@@ -13684,7 +13331,7 @@ class Mission
 			};
 			id=616;
 		};
-		class Item265
+		class Item233
 		{
 			dataType="Group";
 			side="Independent";
@@ -13740,7 +13387,7 @@ class Mission
 			};
 			id=619;
 		};
-		class Item266
+		class Item234
 		{
 			dataType="Group";
 			side="Independent";
@@ -13796,7 +13443,7 @@ class Mission
 			};
 			id=622;
 		};
-		class Item267
+		class Item235
 		{
 			dataType="Group";
 			side="Independent";
@@ -13852,7 +13499,7 @@ class Mission
 			};
 			id=625;
 		};
-		class Item268
+		class Item236
 		{
 			dataType="Group";
 			side="Independent";
@@ -13908,7 +13555,7 @@ class Mission
 			};
 			id=628;
 		};
-		class Item269
+		class Item237
 		{
 			dataType="Group";
 			side="Independent";
@@ -13964,7 +13611,7 @@ class Mission
 			};
 			id=631;
 		};
-		class Item270
+		class Item238
 		{
 			dataType="Group";
 			side="Independent";
@@ -14020,7 +13667,7 @@ class Mission
 			};
 			id=634;
 		};
-		class Item271
+		class Item239
 		{
 			dataType="Group";
 			side="Independent";
@@ -14117,7 +13764,7 @@ class Mission
 			};
 			id=637;
 		};
-		class Item272
+		class Item240
 		{
 			dataType="Group";
 			side="Independent";
@@ -14218,7 +13865,7 @@ class Mission
 			};
 			id=642;
 		};
-		class Item273
+		class Item241
 		{
 			dataType="Group";
 			side="Independent";
@@ -14296,7 +13943,7 @@ class Mission
 			};
 			id=647;
 		};
-		class Item274
+		class Item242
 		{
 			dataType="Group";
 			side="Independent";
@@ -14374,7 +14021,7 @@ class Mission
 			};
 			id=651;
 		};
-		class Item275
+		class Item243
 		{
 			dataType="Group";
 			side="Independent";
@@ -14452,7 +14099,7 @@ class Mission
 			};
 			id=655;
 		};
-		class Item276
+		class Item244
 		{
 			dataType="Group";
 			side="Independent";
@@ -14511,7 +14158,7 @@ class Mission
 			id=659;
 			atlOffset=9.5367432e-007;
 		};
-		class Item277
+		class Item245
 		{
 			dataType="Group";
 			side="Independent";
@@ -14568,7 +14215,7 @@ class Mission
 			};
 			id=662;
 		};
-		class Item278
+		class Item246
 		{
 			dataType="Group";
 			side="Independent";
@@ -14625,7 +14272,7 @@ class Mission
 			};
 			id=665;
 		};
-		class Item279
+		class Item247
 		{
 			dataType="Group";
 			side="Independent";
@@ -14683,7 +14330,7 @@ class Mission
 			};
 			id=668;
 		};
-		class Item280
+		class Item248
 		{
 			dataType="Group";
 			side="Independent";
@@ -14740,7 +14387,7 @@ class Mission
 			};
 			id=671;
 		};
-		class Item281
+		class Item249
 		{
 			dataType="Group";
 			side="Independent";
@@ -14833,7 +14480,7 @@ class Mission
 			};
 			id=674;
 		};
-		class Item282
+		class Item250
 		{
 			dataType="Group";
 			side="West";
@@ -14934,7 +14581,7 @@ class Mission
 			};
 			id=679;
 		};
-		class Item283
+		class Item251
 		{
 			dataType="Group";
 			side="West";
@@ -15036,7 +14683,7 @@ class Mission
 			};
 			id=684;
 		};
-		class Item284
+		class Item252
 		{
 			dataType="Group";
 			side="West";
@@ -15095,7 +14742,7 @@ class Mission
 			id=689;
 			atlOffset=-4.7683716e-007;
 		};
-		class Item285
+		class Item253
 		{
 			dataType="Group";
 			side="West";
@@ -15240,7 +14887,7 @@ class Mission
 			id=692;
 			atlOffset=-4.7683716e-007;
 		};
-		class Item286
+		class Item254
 		{
 			dataType="Group";
 			side="West";
@@ -15385,7 +15032,7 @@ class Mission
 			id=699;
 			atlOffset=-4.7683716e-007;
 		};
-		class Item287
+		class Item255
 		{
 			dataType="Group";
 			side="West";
@@ -15441,7 +15088,7 @@ class Mission
 			};
 			id=706;
 		};
-		class Item288
+		class Item256
 		{
 			dataType="Group";
 			side="West";
@@ -15585,7 +15232,7 @@ class Mission
 			id=709;
 			atlOffset=-4.7683716e-007;
 		};
-		class Item289
+		class Item257
 		{
 			dataType="Group";
 			side="West";
@@ -15726,7 +15373,7 @@ class Mission
 			};
 			id=716;
 		};
-		class Item290
+		class Item258
 		{
 			dataType="Group";
 			side="West";
@@ -15782,7 +15429,7 @@ class Mission
 			};
 			id=723;
 		};
-		class Item291
+		class Item259
 		{
 			dataType="Group";
 			side="West";
@@ -15922,7 +15569,7 @@ class Mission
 			};
 			id=726;
 		};
-		class Item292
+		class Item260
 		{
 			dataType="Group";
 			side="West";
@@ -16063,7 +15710,7 @@ class Mission
 			};
 			id=733;
 		};
-		class Item293
+		class Item261
 		{
 			dataType="Group";
 			side="West";
@@ -16119,7 +15766,7 @@ class Mission
 			};
 			id=740;
 		};
-		class Item294
+		class Item262
 		{
 			dataType="Group";
 			side="West";
@@ -16175,7 +15822,7 @@ class Mission
 			};
 			id=743;
 		};
-		class Item295
+		class Item263
 		{
 			dataType="Group";
 			side="West";
@@ -16231,7 +15878,7 @@ class Mission
 			};
 			id=746;
 		};
-		class Item296
+		class Item264
 		{
 			dataType="Group";
 			side="West";
@@ -16288,7 +15935,7 @@ class Mission
 			};
 			id=749;
 		};
-		class Item297
+		class Item265
 		{
 			dataType="Group";
 			side="West";
@@ -16344,7 +15991,7 @@ class Mission
 			};
 			id=752;
 		};
-		class Item298
+		class Item266
 		{
 			dataType="Group";
 			side="West";
@@ -16401,7 +16048,7 @@ class Mission
 			};
 			id=755;
 		};
-		class Item299
+		class Item267
 		{
 			dataType="Group";
 			side="West";
@@ -16458,7 +16105,7 @@ class Mission
 			};
 			id=758;
 		};
-		class Item300
+		class Item268
 		{
 			dataType="Group";
 			side="West";
@@ -16515,7 +16162,7 @@ class Mission
 			};
 			id=761;
 		};
-		class Item301
+		class Item269
 		{
 			dataType="Group";
 			side="West";
@@ -16572,7 +16219,7 @@ class Mission
 			};
 			id=764;
 		};
-		class Item302
+		class Item270
 		{
 			dataType="Group";
 			side="West";
@@ -16629,7 +16276,7 @@ class Mission
 			};
 			id=767;
 		};
-		class Item303
+		class Item271
 		{
 			dataType="Group";
 			side="West";
@@ -16727,7 +16374,7 @@ class Mission
 			};
 			id=770;
 		};
-		class Item304
+		class Item272
 		{
 			dataType="Group";
 			side="West";
@@ -16784,7 +16431,7 @@ class Mission
 			};
 			id=775;
 		};
-		class Item305
+		class Item273
 		{
 			dataType="Group";
 			side="West";
@@ -16842,7 +16489,7 @@ class Mission
 			id=778;
 			atlOffset=4.7683716e-007;
 		};
-		class Item306
+		class Item274
 		{
 			dataType="Group";
 			side="West";
@@ -16898,7 +16545,7 @@ class Mission
 			};
 			id=781;
 		};
-		class Item307
+		class Item275
 		{
 			dataType="Group";
 			side="West";
@@ -16991,7 +16638,7 @@ class Mission
 			};
 			id=784;
 		};
-		class Item308
+		class Item276
 		{
 			dataType="Group";
 			side="Civilian";
@@ -17047,7 +16694,7 @@ class Mission
 			};
 			id=789;
 		};
-		class Item309
+		class Item277
 		{
 			dataType="Group";
 			side="Civilian";
@@ -17080,7 +16727,7 @@ class Mission
 			};
 			id=791;
 		};
-		class Item310
+		class Item278
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -17092,7 +16739,7 @@ class Mission
 			id=793;
 			type="VirtualCurator_F";
 		};
-		class Item311
+		class Item279
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -17104,7 +16751,7 @@ class Mission
 			id=794;
 			type="VirtualCurator_F";
 		};
-		class Item312
+		class Item280
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -17116,7 +16763,7 @@ class Mission
 			id=795;
 			type="VirtualCurator_F";
 		};
-		class Item313
+		class Item281
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -17127,6 +16774,810 @@ class Mission
 			isPlayable=1;
 			id=796;
 			type="VirtualCurator_F";
+		};
+		class Item282
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={10609.88,20.189512,12643.325};
+			};
+			id=797;
+			type="SupportProvider_Virtual_CAS_Heli";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_cooldown";
+					expression="_this setVariable ['BIS_SUPP_cooldown',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicleInit";
+					expression="_this setVariable ['BIS_SUPP_vehicleInit',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicles";
+					expression="_this setVariable ['BIS_SUPP_vehicles',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[]";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_filter";
+					expression="_this setVariable ['BIS_SUPP_filter',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Side";
+						};
+					};
+				};
+				nAttributes=4;
+			};
+		};
+		class Item283
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={10609.881,19.35586,12627.38};
+			};
+			id=798;
+			type="SupportProvider_Virtual_CAS_Heli";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_cooldown";
+					expression="_this setVariable ['BIS_SUPP_cooldown',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicleInit";
+					expression="_this setVariable ['BIS_SUPP_vehicleInit',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicles";
+					expression="_this setVariable ['BIS_SUPP_vehicles',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[]";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_filter";
+					expression="_this setVariable ['BIS_SUPP_filter',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Side";
+						};
+					};
+				};
+				nAttributes=4;
+			};
+		};
+		class Item284
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={11438.386,25.360546,11794.968};
+			};
+			id=799;
+			type="SupportProvider_Virtual_CAS_Heli";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_cooldown";
+					expression="_this setVariable ['BIS_SUPP_cooldown',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicleInit";
+					expression="_this setVariable ['BIS_SUPP_vehicleInit',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicles";
+					expression="_this setVariable ['BIS_SUPP_vehicles',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[]";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_filter";
+					expression="_this setVariable ['BIS_SUPP_filter',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Side";
+						};
+					};
+				};
+				nAttributes=4;
+			};
+		};
+		class Item285
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={11438.334,24.859396,11778.54};
+			};
+			id=800;
+			type="SupportProvider_Virtual_CAS_Heli";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_cooldown";
+					expression="_this setVariable ['BIS_SUPP_cooldown',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicleInit";
+					expression="_this setVariable ['BIS_SUPP_vehicleInit',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicles";
+					expression="_this setVariable ['BIS_SUPP_vehicles',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[]";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_filter";
+					expression="_this setVariable ['BIS_SUPP_filter',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Side";
+						};
+					};
+				};
+				nAttributes=4;
+			};
+		};
+		class Item286
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={10573.848,7.076189,11291.686};
+				angles[]={6.2618566,0,6.2685208};
+			};
+			id=801;
+			type="SupportProvider_Virtual_CAS_Heli";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_cooldown";
+					expression="_this setVariable ['BIS_SUPP_cooldown',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicleInit";
+					expression="_this setVariable ['BIS_SUPP_vehicleInit',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicles";
+					expression="_this setVariable ['BIS_SUPP_vehicles',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[]";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_filter";
+					expression="_this setVariable ['BIS_SUPP_filter',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Side";
+						};
+					};
+				};
+				nAttributes=4;
+			};
+		};
+		class Item287
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={10573.293,7.7925463,11308.771};
+			};
+			id=802;
+			type="SupportProvider_Virtual_CAS_Heli";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_cooldown";
+					expression="_this setVariable ['BIS_SUPP_cooldown',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicleInit";
+					expression="_this setVariable ['BIS_SUPP_vehicleInit',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicles";
+					expression="_this setVariable ['BIS_SUPP_vehicles',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[]";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_filter";
+					expression="_this setVariable ['BIS_SUPP_filter',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Side";
+						};
+					};
+				};
+				nAttributes=4;
+			};
+		};
+		class Item288
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={10346.912,12.932244,11899.851};
+			};
+			id=803;
+			type="SupportProvider_Virtual_CAS_Heli";
+			atlOffset=-9.5367432e-007;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_cooldown";
+					expression="_this setVariable ['BIS_SUPP_cooldown',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicleInit";
+					expression="_this setVariable ['BIS_SUPP_vehicleInit',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicles";
+					expression="_this setVariable ['BIS_SUPP_vehicles',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[]";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_filter";
+					expression="_this setVariable ['BIS_SUPP_filter',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Side";
+						};
+					};
+				};
+				nAttributes=4;
+			};
+		};
+		class Item289
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={10346.518,13.330898,11915.982};
+			};
+			id=804;
+			type="SupportProvider_Virtual_CAS_Heli";
+			atlOffset=9.5367432e-007;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_cooldown";
+					expression="_this setVariable ['BIS_SUPP_cooldown',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicleInit";
+					expression="_this setVariable ['BIS_SUPP_vehicleInit',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_vehicles";
+					expression="_this setVariable ['BIS_SUPP_vehicles',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[]";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportProvider_Virtual_CAS_Heli_BIS_SUPP_filter";
+					expression="_this setVariable ['BIS_SUPP_filter',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Side";
+						};
+					};
+				};
+				nAttributes=4;
+			};
+		};
+		class Item290
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={10342.236,12.939924,11916.079};
+			};
+			id=813;
+			type="SupportProvider_Artillery";
+			atlOffset=-9.5367432e-007;
+		};
+		class Item291
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={10569.258,7.155221,11291.229};
+			};
+			id=814;
+			type="SupportProvider_Artillery";
+		};
+		class Item292
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={10342.631,12.987046,11899.947};
+			};
+			id=815;
+			type="SupportProvider_Artillery";
+		};
+		class Item293
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={10605.6,19.375135,12627.477};
+			};
+			id=816;
+			type="SupportProvider_Artillery";
+		};
+		class Item294
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={10605.599,20.064135,12643.422};
+			};
+			id=817;
+			type="SupportProvider_Artillery";
+		};
+		class Item295
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={11434.053,25.027555,11778.637};
+			};
+			id=818;
+			type="SupportProvider_Artillery";
+		};
+		class Item296
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={11434.104,25.597261,11795.064};
+			};
+			id=819;
+			type="SupportProvider_Artillery";
+		};
+		class Item297
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={10569.012,7.8425264,11308.867};
+			};
+			id=820;
+			type="SupportProvider_Artillery";
 		};
 	};
 	class Connections
@@ -17141,7 +17592,7 @@ class Mission
 			class Item0
 			{
 				linkID=0;
-				item0=111;
+				item0=813;
 				item1=110;
 				class CustomData
 				{
@@ -17151,7 +17602,7 @@ class Mission
 			class Item1
 			{
 				linkID=1;
-				item0=112;
+				item0=804;
 				item1=110;
 				class CustomData
 				{
@@ -17172,7 +17623,7 @@ class Mission
 			{
 				linkID=3;
 				item0=115;
-				item1=111;
+				item1=813;
 				class CustomData
 				{
 					type="Sync";
@@ -17182,7 +17633,7 @@ class Mission
 			{
 				linkID=4;
 				item0=118;
-				item1=112;
+				item1=804;
 				class CustomData
 				{
 					type="Sync";
@@ -17191,7 +17642,7 @@ class Mission
 			class Item5
 			{
 				linkID=5;
-				item0=121;
+				item0=820;
 				item1=120;
 				class CustomData
 				{
@@ -17201,7 +17652,7 @@ class Mission
 			class Item6
 			{
 				linkID=6;
-				item0=122;
+				item0=802;
 				item1=120;
 				class CustomData
 				{
@@ -17222,7 +17673,7 @@ class Mission
 			{
 				linkID=8;
 				item0=125;
-				item1=121;
+				item1=820;
 				class CustomData
 				{
 					type="Sync";
@@ -17232,7 +17683,7 @@ class Mission
 			{
 				linkID=9;
 				item0=128;
-				item1=122;
+				item1=802;
 				class CustomData
 				{
 					type="Sync";
@@ -17241,7 +17692,7 @@ class Mission
 			class Item10
 			{
 				linkID=10;
-				item0=131;
+				item0=814;
 				item1=130;
 				class CustomData
 				{
@@ -17251,7 +17702,7 @@ class Mission
 			class Item11
 			{
 				linkID=11;
-				item0=132;
+				item0=801;
 				item1=130;
 				class CustomData
 				{
@@ -17272,7 +17723,7 @@ class Mission
 			{
 				linkID=13;
 				item0=135;
-				item1=131;
+				item1=814;
 				class CustomData
 				{
 					type="Sync";
@@ -17282,7 +17733,7 @@ class Mission
 			{
 				linkID=14;
 				item0=138;
-				item1=132;
+				item1=801;
 				class CustomData
 				{
 					type="Sync";
@@ -17291,7 +17742,7 @@ class Mission
 			class Item15
 			{
 				linkID=15;
-				item0=141;
+				item0=819;
 				item1=140;
 				class CustomData
 				{
@@ -17301,7 +17752,7 @@ class Mission
 			class Item16
 			{
 				linkID=16;
-				item0=142;
+				item0=799;
 				item1=140;
 				class CustomData
 				{
@@ -17322,7 +17773,7 @@ class Mission
 			{
 				linkID=18;
 				item0=149;
-				item1=141;
+				item1=819;
 				class CustomData
 				{
 					type="Sync";
@@ -17332,7 +17783,7 @@ class Mission
 			{
 				linkID=19;
 				item0=145;
-				item1=142;
+				item1=799;
 				class CustomData
 				{
 					type="Sync";
@@ -17341,7 +17792,7 @@ class Mission
 			class Item20
 			{
 				linkID=20;
-				item0=151;
+				item0=818;
 				item1=150;
 				class CustomData
 				{
@@ -17351,7 +17802,7 @@ class Mission
 			class Item21
 			{
 				linkID=21;
-				item0=152;
+				item0=800;
 				item1=150;
 				class CustomData
 				{
@@ -17372,7 +17823,7 @@ class Mission
 			{
 				linkID=23;
 				item0=159;
-				item1=151;
+				item1=818;
 				class CustomData
 				{
 					type="Sync";
@@ -17382,7 +17833,7 @@ class Mission
 			{
 				linkID=24;
 				item0=155;
-				item1=152;
+				item1=800;
 				class CustomData
 				{
 					type="Sync";
@@ -17391,7 +17842,7 @@ class Mission
 			class Item25
 			{
 				linkID=25;
-				item0=161;
+				item0=817;
 				item1=160;
 				class CustomData
 				{
@@ -17401,7 +17852,7 @@ class Mission
 			class Item26
 			{
 				linkID=26;
-				item0=162;
+				item0=797;
 				item1=160;
 				class CustomData
 				{
@@ -17422,7 +17873,7 @@ class Mission
 			{
 				linkID=28;
 				item0=169;
-				item1=161;
+				item1=817;
 				class CustomData
 				{
 					type="Sync";
@@ -17432,7 +17883,7 @@ class Mission
 			{
 				linkID=29;
 				item0=165;
-				item1=162;
+				item1=797;
 				class CustomData
 				{
 					type="Sync";
@@ -17441,7 +17892,7 @@ class Mission
 			class Item30
 			{
 				linkID=30;
-				item0=171;
+				item0=816;
 				item1=170;
 				class CustomData
 				{
@@ -17451,7 +17902,7 @@ class Mission
 			class Item31
 			{
 				linkID=31;
-				item0=172;
+				item0=798;
 				item1=170;
 				class CustomData
 				{
@@ -17472,7 +17923,7 @@ class Mission
 			{
 				linkID=33;
 				item0=179;
-				item1=171;
+				item1=816;
 				class CustomData
 				{
 					type="Sync";
@@ -17482,7 +17933,7 @@ class Mission
 			{
 				linkID=34;
 				item0=175;
-				item1=172;
+				item1=798;
 				class CustomData
 				{
 					type="Sync";
@@ -17491,7 +17942,7 @@ class Mission
 			class Item35
 			{
 				linkID=35;
-				item0=181;
+				item0=815;
 				item1=180;
 				class CustomData
 				{
@@ -17501,7 +17952,7 @@ class Mission
 			class Item36
 			{
 				linkID=36;
-				item0=182;
+				item0=803;
 				item1=180;
 				class CustomData
 				{
@@ -17522,7 +17973,7 @@ class Mission
 			{
 				linkID=38;
 				item0=185;
-				item1=181;
+				item1=815;
 				class CustomData
 				{
 					type="Sync";
@@ -17532,7 +17983,7 @@ class Mission
 			{
 				linkID=39;
 				item0=188;
-				item1=182;
+				item1=803;
 				class CustomData
 				{
 					type="Sync";

--- a/mission.sqm
+++ b/mission.sqm
@@ -4887,7 +4887,7 @@ class Mission
 					{
 						skill=0.60000002;
 						rank="LIEUTENANT";
-						init="GrpNATO_CO = group this; [""co"",this] call f_fnc_assignGear;";
+						init="[""co"",this] call f_fnc_assignGear;";
 						name="UnitNATO_CO";
 						description="NATO Commander";
 						isPlayable=1;
@@ -4909,7 +4909,7 @@ class Mission
 					{
 						skill=0.60000002;
 						rank="SERGEANT";
-						init="GrpNATO_CO = group this; [""jtac"",this] call f_fnc_assignGear;";
+						init="[""jtac"",this] call f_fnc_assignGear;";
 						name="UnitNATO_CO_JTAC";
 						description="NATO JTAC";
 						isPlayable=1;
@@ -4931,7 +4931,7 @@ class Mission
 					{
 						skill=0.60000002;
 						rank="CORPORAL";
-						init="GrpNATO_CO = group this; [""uav"",this] call f_fnc_assignGear;";
+						init="[""uav"",this] call f_fnc_assignGear;";
 						name="UnitNATO_CO_UAV";
 						description="NATO UAV Operator";
 						isPlayable=1;
@@ -4952,7 +4952,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpNATO_CO = group this; [""m"",this] call f_fnc_assignGear;";
+						init="[""m"",this] call f_fnc_assignGear;";
 						name="UnitNATO_CO_M";
 						description="NATO Medic";
 						isPlayable=1;
@@ -4963,8 +4963,32 @@ class Mission
 			};
 			class Attributes
 			{
+				name="GrpNATO_CO";
 			};
 			id=190;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="NATO CO";
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 		class Item135
 		{
@@ -8374,7 +8398,7 @@ class Mission
 						skill=0.60000002;
 						rank="LIEUTENANT";
 						lock="UNLOCKED";
-						init="GrpCSAT_CO = group this; [""co"",this] call f_fnc_assignGear;";
+						init="[""co"",this] call f_fnc_assignGear;";
 						name="UnitCSAT_CO";
 						description="CSAT Commander";
 						isPlayable=1;
@@ -8396,7 +8420,7 @@ class Mission
 					{
 						skill=0.60000002;
 						rank="CORPORAL";
-						init="GrpCSAT_CO = group this; [""jtac"",this] call f_fnc_assignGear;";
+						init="[""jtac"",this] call f_fnc_assignGear;";
 						name="UnitCSAT_CO_JTAC";
 						description="CSAT JTAC";
 						isPlayable=1;
@@ -8418,7 +8442,7 @@ class Mission
 					{
 						skill=0.60000002;
 						rank="CORPORAL";
-						init="GrpCSAT_CO = group this; [""uav"",this] call f_fnc_assignGear;";
+						init="[""uav"",this] call f_fnc_assignGear;";
 						name="UnitCSAT_CO_UAV";
 						description="CSAT UAV Operator";
 						isPlayable=1;
@@ -8439,7 +8463,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpCSAT_CO = group this; [""m"",this] call f_fnc_assignGear;";
+						init="[""m"",this] call f_fnc_assignGear;";
 						name="UnitCSAT_CO_M";
 						description="CSAT Medic";
 						isPlayable=1;
@@ -8450,8 +8474,32 @@ class Mission
 			};
 			class Attributes
 			{
+				name="GrpCSAT_CO";
 			};
 			id=367;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="CSAT CO";
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 		class Item175
 		{
@@ -11608,7 +11656,7 @@ class Mission
 					{
 						skill=0.60000002;
 						rank="LIEUTENANT";
-						init="GrpAAF_CO = group this; [""co"",this] call f_fnc_assignGear;";
+						init="[""co"",this] call f_fnc_assignGear;";
 						name="UnitAAF_CO";
 						description="AAF Commander";
 						isPlayable=1;
@@ -11629,7 +11677,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpAAF_CO = group this; [""jtac"",this] call f_fnc_assignGear;";
+						init="[""jtac"",this] call f_fnc_assignGear;";
 						name="UnitAAF_CO_JTAC";
 						description="AAF Forward Observer";
 						isPlayable=1;
@@ -11650,7 +11698,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpAAF_CO = group this; [""uav"",this] call f_fnc_assignGear;";
+						init="[""uav"",this] call f_fnc_assignGear;";
 						name="UnitAAF_CO_UAV";
 						description="AAF UAV Operator";
 						isPlayable=1;
@@ -11671,7 +11719,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpAAF_CO = group this; [""m"",this] call f_fnc_assignGear;";
+						init="[""m"",this] call f_fnc_assignGear;";
 						name="UnitAAF_CO_M";
 						description="AAF Medic";
 						isPlayable=1;
@@ -11682,8 +11730,32 @@ class Mission
 			};
 			class Attributes
 			{
+				name="GrpAAF_CO";
 			};
 			id=530;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="AAF CO";
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 		class Item215
 		{
@@ -14501,7 +14573,7 @@ class Mission
 					{
 						skill=0.60000002;
 						rank="LIEUTENANT";
-						init="GrpFIA_CO = group this; [""co"",this,""ctrg""] call f_fnc_assignGear;";
+						init="[""co"",this,""ctrg""] call f_fnc_assignGear;";
 						name="UnitFIA_CO";
 						description="CTRG Commander";
 						isPlayable=1;
@@ -14523,7 +14595,7 @@ class Mission
 					{
 						skill=0.60000002;
 						rank="CORPORAL";
-						init="GrpFIA_CO = group this; [""jtac"",this,""ctrg""] call f_fnc_assignGear;";
+						init="[""jtac"",this,""ctrg""] call f_fnc_assignGear;";
 						name="UnitFIA_CO_JTAC";
 						description="CTRG JTAC";
 						isPlayable=1;
@@ -14544,7 +14616,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpFIA_CO = group this; [""uav"",this] call f_fnc_assignGear;";
+						init="[""uav"",this] call f_fnc_assignGear;";
 						name="UnitFIA_CO_UAV";
 						description="FIA UAV Operator";
 						isPlayable=1;
@@ -14566,7 +14638,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpFIA_CO = group this; [""m"",this] call f_fnc_assignGear;";
+						init="[""m"",this] call f_fnc_assignGear;";
 						name="UnitFIA_CO_M";
 						description="FIA Medic";
 						isPlayable=1;
@@ -14578,8 +14650,32 @@ class Mission
 			};
 			class Attributes
 			{
+				name="GrpFIA_CO";
 			};
 			id=679;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="FIA CO";
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 		class Item251
 		{


### PR DESCRIPTION
***Note:*** Includes PR #720 

Implements the middle-ground solution discussed in #715 

* Configured all CO groups to use the new system
* New groupMarker component configuration:
 - Split into sub-scripts by sides
 - Marker types are now defined in the main script (and can be overridden on a per-group basis)

* For now the old system for groupMarkers & groupID exists as legacy versions (commented out)
* ToDo (in a future PR): Go through all groups and update them to the new standard. This requires:
 - Setting group variable & callsign in the group configuration window
 -  Removing ```GrpX_Y = group this``` from all unit inits.