### PR TITLE
APEX preparations

### DIFF
--- a/briefing.sqf
+++ b/briefing.sqf
@@ -49,10 +49,10 @@ if (serverCommandAvailable "#kick") then {
 // ====================================================================================
 
 // BRIEFING: BLUFOR > NATO
-// The following block of code executes only if the player is in a NATO slot; it
+// The following block of code executes only if the player is in a NATO or NATO (Pacific) slot; it
 // automatically includes a file which contains the appropriate briefing data.
 
-if (_unitfaction == "blu_f") exitwith {
+if (_unitfaction in ["blu_f","blu_t_f"]) exitwith {
 
 #include "f\briefing\f_briefing_nato.sqf"
 
@@ -83,10 +83,10 @@ if (_unitfaction in ["blu_g_f","ind_g_f","opf_g_f"]) exitwith {
 // ====================================================================================
 
 // BRIEFING: OPFOR > CSAT
-// The following block of code executes only if the player is in a CSAT slot; it
+// The following block of code executes only if the player is in a CSAT & CSAT (Pacific) slot; it
 // automatically includes a file which contains the appropriate briefing data.
 
-if (_unitfaction == "opf_f") exitwith {
+if (_unitfaction in ["opf_f","opf_t_f"]) exitwith {
 
 #include "f\briefing\f_briefing_csat.sqf"
 
@@ -103,7 +103,7 @@ if (_unitfaction == "opf_f") exitwith {
 // The following block of code executes only if the player is in a AAF
 // slot; it automatically includes a file which contains the appropriate briefing data.
 
-if (_unitfaction == "ind_f") exitwith {
+if (_unitfaction in ["ind_f"]) exitwith {
 
 #include "f\briefing\f_briefing_aaf.sqf"
 
@@ -120,7 +120,7 @@ if (_unitfaction == "ind_f") exitwith {
 // The following block of code executes only if the player is in a Syndikat
 // slot; it automatically includes a file which contains the appropriate briefing data.
 
-if (_unitfaction == "ind_c_f") exitwith {
+if (_unitfaction in ["ind_c_f"]) exitwith {
 
 #include "f\briefing\f_briefing_syndikat.sqf"
 
@@ -137,7 +137,7 @@ if (_unitfaction == "ind_c_f") exitwith {
 // The following block of code executes only if the player is in a CIVILIAN
 // slot; it automatically includes a file which contains the appropriate briefing data.
 
-if (_unitfaction == "civ_f") exitwith {
+if (_unitfaction in ["civ_f"]) exitwith {
 
 #include "f\briefing\f_briefing_civ.sqf"
 

--- a/briefing.sqf
+++ b/briefing.sqf
@@ -133,6 +133,23 @@ if (_unitfaction in ["ind_c_f"]) exitwith {
 
 // ====================================================================================
 
+// BRIEFING: INDEPENDENT > CTRG
+// The following block of code executes only if the player is in a Syndikat
+// slot; it automatically includes a file which contains the appropriate briefing data.
+
+if (_unitfaction in ["blu_ctrg_f"]) exitwith {
+
+#include "f\briefing\f_briefing_ctrg.sqf"
+
+// DEBUG
+	if (f_param_debugMode == 1) then
+	{
+	player sideChat format ["DEBUG (briefing.sqf): Briefing for %1 slot selected.",_unitfaction];
+	};
+};
+
+// ====================================================================================
+
 // BRIEFING: CIVILIAN
 // The following block of code executes only if the player is in a CIVILIAN
 // slot; it automatically includes a file which contains the appropriate briefing data.

--- a/f/assignGear/f_assignGear_clothes.sqf
+++ b/f/assignGear/f_assignGear_clothes.sqf
@@ -13,6 +13,7 @@ _unit setVariable ["BIS_enableRandomization", false];
 removeUniform _unit;
 removeHeadgear _unit;
 removeVest _unit;
+removeGoggles _unit;
 
 // Assign default clothes
 _uniform = _baseUniform;

--- a/f/assignGear/f_assignGear_csatpacific.sqf
+++ b/f/assignGear/f_assignGear_csatpacific.sqf
@@ -1,0 +1,915 @@
+// F3 - Folk ARPS Assign Gear Script - CSAT
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+// ====================================================================================
+
+// DEFINE EQUIPMENT TABLES
+// The blocks of code below identifies equipment for this faction
+//
+// Defined loadouts:
+//		co			- commander
+//		dc 			- deputy commander / squad leader
+//		m 			- medic
+//		ftl			- fire team leader
+//		ar 			- automatic rifleman
+//		aar			- assistant automatic rifleman
+//		rat			- rifleman (AT)
+//		dm			- designated marksman
+//		mmgg		- medium mg gunner
+//		mmgag		- medium mg assistant
+//		matg		- medium AT gunner
+//		matag		- medium AT assistant
+//		hmgg		- heavy mg gunner (deployable)
+//		hmgag		- heavy mg assistant (deployable)
+//		hatg		- heavy AT gunner (deployable)
+//		hatag		- heavy AT assistant (deployable)
+//		mtrg		- mortar gunner (deployable)
+//		mtrag		- mortar assistant (deployable)
+//		msamg		- medium SAM gunner
+//		msamag		- medium SAM assistant gunner
+//		hsamg		- heavy SAM gunner (deployable)
+//		hsamag		- heavy SAM assistant gunner (deployable)
+//		sn			- sniper
+//		sp			- spotter (for sniper)
+//		vc			- vehicle commander
+//		vg			- vehicle gunner
+//		vd			- vehicle driver (repair)
+//		pp			- air vehicle pilot / co-pilot
+//		pcc			- air vehicle co-pilot (repair) / crew chief (repair)
+//		pc			- air vehicle crew
+//		eng			- engineer (demo)
+//		engm		- engineer (mines)
+//		uav			- UAV operator
+//		div    		- divers
+//
+//		r 			- rifleman
+//		car			- carabineer
+//		smg			- submachinegunner
+//		gren		- grenadier
+//
+//		v_car		- car/4x4
+//		v_tr		- truck
+//		v_ifv		- ifv
+//
+//		crate_small	- small ammocrate
+//		crate_med	- medium ammocrate
+//		crate_large	- large ammocrate
+//
+// ====================================================================================
+
+// GENERAL EQUIPMENT USED BY MULTIPLE CLASSES
+
+// ATTACHMENTS - PRIMARY
+_attach1 = "acc_pointer_IR";	// IR Laser
+_attach2 = "acc_flashlight";	// Flashlight
+
+_silencer1 = "muzzle_snds_M";	// 5.56 suppressor
+_silencer2 = "muzzle_snds_H";	// 6.5 suppressor
+
+_scope1 = "optic_ACO_grn";		// ACO
+_scope2 = "optic_MRCO";			// MRCO Scope - 1x - 6x
+_scope3 = "optic_SOS";			// SOS Scope - 18x - 75x
+
+_bipod1 = "bipod_02_F_hex";		// Default bipod
+_bipod2 = "bipod_02_F_blk";		// Black bipod
+
+// Default setup
+_attachments = [_attach1,_scope1]; // The default attachment set for most units, overwritten in the individual unitType
+
+// [] = remove all
+// [_attach1,_scope1,_silencer] = remove all, add items assigned in _attach1, _scope1 and _silencer1
+// [_scope2] = add _scope2, remove rest
+// false = keep attachments as they are
+
+// ====================================================================================
+
+// ATTACHMENTS - HANDGUN
+_hg_silencer1 = "muzzle_snds_L";	// 9mm suppressor
+
+_hg_scope1 = "optic_MRD";			// MRD
+
+// Default setup
+_hg_attachments= []; // The default attachment set for handguns, overwritten in the individual unitType
+
+// ====================================================================================
+
+// WEAPON SELECTION
+
+// Standard Riflemen ( MMG Assistant Gunner, Assistant Automatic Rifleman, MAT Assistant Gunner, MTR Assistant Gunner, Rifleman)
+_rifle = "arifle_Katiba_F";
+_riflemag = "30Rnd_65x39_caseless_green";
+_riflemag_tr = "30Rnd_65x39_caseless_green_mag_Tracer";
+
+// Standard Carabineer (Medic, Rifleman (AT), MAT Gunner, MTR Gunner, Carabineer)
+_carbine = "arifle_Katiba_C_F";
+_carbinemag = "30Rnd_65x39_caseless_green";
+_carbinemag_tr = "30Rnd_65x39_caseless_green_mag_Tracer";
+
+// Standard Submachine Gun/Personal Defence Weapon (Aircraft Pilot, Submachinegunner)
+_smg = "SMG_02_F";
+_smgmag = "30Rnd_9x21_Mag";
+_smgmag_tr = "30Rnd_9x21_Mag";
+
+// Diver
+_diverWep = "arifle_SDAR_F";
+_diverMag1 = "30Rnd_556x45_Stanag";
+_diverMag2 = "20Rnd_556x45_UW_mag";
+
+// Rifle with GL and HE grenades (CO, DC, FTLs)
+_glrifle = "arifle_Katiba_GL_F";
+_glriflemag = "30Rnd_65x39_caseless_green";
+_glriflemag_tr = "30Rnd_65x39_caseless_green_mag_Tracer";
+_glmag = "1Rnd_HE_Grenade_shell";
+
+// Smoke for FTLs, Squad Leaders, etc
+_glsmokewhite = "1Rnd_Smoke_Grenade_shell";
+_glsmokegreen = "1Rnd_SmokeGreen_Grenade_shell";
+_glsmokered = "1Rnd_SmokeRed_Grenade_shell";
+
+// Flares for FTLs, Squad Leaders, etc
+_glflarewhite = "UGL_FlareWhite_F";
+_glflarered = "UGL_FlareRed_F";
+_glflareyellow = "UGL_FlareYellow_F";
+_glflaregreen = "UGL_FlareGreen_F";
+
+// Pistols (CO, DC, Automatic Rifleman, Medium MG Gunner)
+_pistol = "hgun_Rook40_F";
+_pistolmag = "16Rnd_9x21_Mag";
+
+// Grenades
+_grenade = "HandGrenade";
+_Mgrenade = "MiniGrenade";
+_smokegrenade = "SmokeShell";
+_smokegrenadegreen = "SmokeShellGreen";
+
+// misc medical items.
+_firstaid = "FirstAidKit";
+_medkit = "Medikit";
+
+// Night Vision Goggles (NVGoggles)
+_nvg = "NVGoggles_OPFOR";
+
+// UAV Terminal
+_uavterminal = "O_UavTerminal";
+
+// Chemlights
+_chemgreen =  "Chemlight_green";
+_chemred = "Chemlight_red";
+_chemyellow =  "Chemlight_yellow";
+_chemblue = "Chemlight_blue";
+
+// Backpacks
+_bagsmall = "B_AssaultPack_ocamo";			// carries 120, weighs 20
+_bagmedium = "B_FieldPack_ocamo";			// carries 200, weighs 30
+_baglarge =  "B_Carryall_ocamo"; 			// carries 320, weighs 40
+_bagmediumdiver =  "B_AssaultPack_blk";		// used by divers
+_baguav = "O_UAV_01_backpack_F";			// used by UAV operator
+_baghmgg = "O_HMG_01_weapon_F";				// used by Heavy MG gunner
+_baghmgag = "O_HMG_01_support_F";			// used by Heavy MG assistant gunner
+_baghatg = "O_AT_01_weapon_F";				// used by Heavy AT gunner
+_baghatag = "O_HMG_01_support_F";			// used by Heavy AT assistant gunner
+_bagmtrg = "O_Mortar_01_weapon_F";			// used by Mortar gunner
+_bagmtrag = "O_Mortar_01_support_F";		// used by Mortar assistant gunner
+_baghsamg = "O_AA_01_weapon_F";				// used by Heavy SAM gunner
+_baghsamag = "O_HMG_01_support_F";			// used by Heavy SAM assistant gunner
+
+// ====================================================================================
+
+// UNIQUE, ROLE-SPECIFIC EQUIPMENT
+
+// Automatic Rifleman
+_AR = "LMG_Zafir_F";
+_ARmag = "150Rnd_762x54_Box";
+_ARmag_tr = "150Rnd_762x54_Box_Tracer";
+
+// Medium MG
+_MMG = "MMG_01_hex_F";
+_MMGmag = "150Rnd_93x64_Mag";
+_MMGmag_tr = "150Rnd_93x64_Mag";
+
+// NON-DLC ALTERNATIVE:
+//_MMG = "LMG_Zafir_F";
+//_MMGmag = ""150Rnd_762x54_Box"";
+//_MMGmag_tr = "150Rnd_762x54_Box_Tracer";
+
+// Marksman rifle
+_DMrifle = "srifle_DMR_05_hex_F";
+_DMriflemag = "10Rnd_93x64_DMR_05_Mag";
+
+// ASP1-KIR
+// _DMrifle = "srifle_DMR_04_F";
+// _DMriflemag = "10Rnd_127x54_Mag";
+
+// Rifleman AT
+_RAT = "launch_RPG32_F";
+_RATmag = "RPG32_F";
+
+// Medium AT
+_MAT = "launch_NLAW_F";
+_MATmag1 = "NLAW_F";
+_MATmag2 = "NLAW_F";
+
+// Surface Air
+_SAM = "launch_O_Titan_F";
+_SAMmag = "Titan_AA";
+
+// Heavy AT
+_HAT = "launch_O_Titan_short_F";
+_HATmag1 = "Titan_AT";
+_HATmag2 = "Titan_AP";
+
+// Sniper
+_SNrifle = "srifle_GM6_F";
+_SNrifleMag = "5Rnd_127x108_Mag";
+
+// Engineer items
+_ATmine = "ATMine_Range_Mag";
+_satchel = "DemoCharge_Remote_Mag";
+_APmine1 = "APERSBoundingMine_Range_Mag";
+_APmine2 = "APERSMine_Range_Mag";
+
+// ====================================================================================
+
+// CLOTHES AND UNIFORMS
+
+// Define classes. This defines which gear class gets which uniform
+// "medium" vests are used for all classes if they are not assigned a specific uniform
+
+_light = [];
+_heavy =  ["eng","engm"];
+_diver = ["div"];
+_pilot = ["pp","pcc","pc"];
+_crew = ["vc","vg","vd"];
+_ghillie = ["sn","sp"];
+_specOp = [];
+
+// Basic clothing
+// The outfit-piece is randomly selected from the array for each unit
+
+// Woodland-Hex
+_baseUniform = ["U_O_CombatUniform_ocamo"];
+_baseHelmet = ["H_HelmetO_ocamo"];
+_baseGlasses = [];
+
+// Urban
+//_baseUniform = ["U_O_CombatUniform_oucamo"];
+//_baseHelmet = ["H_HelmetO_oucamo"];
+
+// Vests
+_lightRig = ["V_HarnessO_brn"];
+_mediumRig = ["V_TacVest_khk"]; 	// default for all infantry classes
+_heavyRig = _mediumRig;
+
+// Diver
+_diverUniform =  ["U_O_Wetsuit"];
+_diverHelmet = [];
+_diverRig = ["V_RebreatherIR"];
+_diverGlasses = ["G_Diving"];
+
+// Pilot
+_pilotUniform = ["U_O_PilotCoveralls"];
+_pilotHelmet = ["H_PilotHelmetHeli_O"];
+_pilotRig = ["V_HarnessO_brn"];
+_pilotGlasses = [];
+
+// Crewman
+_crewUniform = ["U_O_SpecopsUniform_ocamo"];
+_crewHelmet = ["H_HelmetCrew_O"];
+_crewRig = ["V_HarnessO_brn"];
+_crewGlasses = [];
+
+// Ghillie
+_ghillieUniform = ["U_O_GhillieSuit"]; //DLC alternatives: ["U_O_FullGhillie_lsh","U_O_FullGhillie_ard","U_O_FullGhillie_sard"];
+_ghillieHelmet = [];
+_ghillieRig = ["V_Chestrig_khk"];
+_ghillieGlasses = [];
+
+// Spec Op
+_sfuniform = ["U_O_SpecopsUniform_ocamo"];
+_sfhelmet = ["H_HelmetSpecO_ocamo","H_HelmetSpecO_blk"];
+_sfRig = ["V_PlateCarrier1_blk"];
+_sfGlasses = [];
+
+
+// ====================================================================================
+
+// INTERPRET PASSED VARIABLES
+// The following inrerprets formats what has been passed to this script element
+
+_typeofUnit = toLower (_this select 0);			// Tidy input for SWITCH/CASE statements, expecting something like : r = Rifleman, co = Commanding Officer, rat = Rifleman (AT)
+_unit = _this select 1;					// expecting name of unit; originally passed by using 'this' in unit init
+_isMan = _unit isKindOf "CAManBase";	// We check if we're dealing with a soldier or a vehicle
+
+// ====================================================================================
+
+// This block needs only to be run on an infantry unit
+if (_isMan) then {
+
+		// PREPARE UNIT FOR GEAR ADDITION
+	// The following code removes all existing weapons, items, magazines and backpacks
+
+	removeBackpack _unit;
+	removeAllWeapons _unit;
+	removeAllItemsWithMagazines _unit;
+	removeAllAssignedItems _unit;
+
+	// ====================================================================================
+
+	// HANDLE CLOTHES
+	// Handle clothes and helmets and such using the include file called next.
+
+	#include "f_assignGear_clothes.sqf";
+
+	// ====================================================================================
+
+	// ADD UNIVERSAL ITEMS
+	// Add items universal to all units of this faction
+
+	_unit linkItem _nvg;			// Add and equip the faction's nvg
+	_unit addItem _firstaid;		// Add a single first aid kit (FAK)
+	_unit linkItem "ItemMap";		// Add and equip the map
+	_unit linkItem "ItemCompass";	// Add and equip a compass
+	_unit linkItem "ItemRadio";		// Add and equip A3's default radio
+	_unit linkItem "ItemWatch";		// Add and equip a watch
+	_unit linkItem "ItemGPS"; 	// Add and equip a GPS
+
+};
+
+// ====================================================================================
+
+// SETUP BACKPACKS
+// Include the correct backpack file for the faction
+
+_backpack = {
+	_typeofBackPack = _this select 0;
+	_loadout = f_param_backpacks;
+	if (count _this > 1) then {_loadout = _this select 1};
+	switch (_typeofBackPack) do
+	{
+		#include "f_assignGear_csat_b.sqf";
+	};
+};
+
+// ====================================================================================
+
+// DEFINE UNIT TYPE LOADOUTS
+// The following blocks of code define loadouts for each type of unit (the unit type
+// is passed to the script in the first variable)
+
+switch (_typeofUnit) do
+{
+
+// ====================================================================================
+
+// LOADOUT: COMMANDER
+	case "co":
+	{
+		_unit addmagazines [_glriflemag,1];
+		_unit addmagazines [_glriflemag_tr,3];
+		_unit addmagazines [_glsmokered,3];
+		_unit addmagazines [_glflarered,5];
+		_unit addweapon _glrifle;					//_COrifle
+		_unit addmagazines [_pistolmag,4];
+		_unit addweapon _pistol;
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,1];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		_unit addmagazines [_smokegrenadegreen,1];
+		_unit addWeapon "Rangefinder";
+		_unit linkItem "ItemGPS";
+		["g"] call _backpack;
+	};
+
+// LOADOUT: DEPUTY COMMANDER AND SQUAD LEADER
+	case "dc":
+	{
+		_unit addmagazines [_glriflemag,1];
+		_unit addmagazines [_glriflemag_tr,3];
+		_unit addmagazines [_glmag,3];
+		_unit addmagazines [_glsmokered,3];
+		_unit addmagazines [_glflarered,3];
+		_unit addweapon _glrifle;					//_DCrifle
+		_unit addmagazines [_pistolmag,4];
+		_unit addweapon _pistol;
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,1];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		_unit addmagazines [_smokegrenadegreen,1];
+		_unit addWeapon "Rangefinder";
+		_unit linkItem "ItemGPS";
+		["g"] call _backpack;
+	};
+
+// LOADOUT: JTAC
+	case "jtac":
+	{
+		_unit addmagazines [_glriflemag,1];
+		_unit addmagazines [_glsmokered,10];
+		_unit addmagazines [_glflarered,3];
+		_unit addweapon _glrifle;					//_JTACrifle
+		_unit addmagazines [_pistolmag,4];
+		_unit addweapon _pistol;
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,1];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		_unit addmagazines [_smokegrenadegreen,1];
+		_unit addMagazines ["Laserbatteries",1];
+		_unit addWeapon "Laserdesignator";
+		_unit linkItem "ItemGPS";
+		["g"] call _backpack;
+	};
+
+// LOADOUT: MEDIC
+	case "m":
+	{
+		_unit addmagazines [_carbinemag,9];
+		_unit addweapon _carbine;
+		_unit addmagazines [_smokegrenade,4];
+		{_unit addItem _firstaid} forEach [1,2,3,4];
+		_unit linkItem "ItemGPS";
+		["m"] call _backpack;
+	};
+
+// LOADOUT: FIRETEAM LEADER
+	case "ftl":
+	{
+		_unit addmagazines [_glriflemag,4];
+		_unit addmagazines [_glriflemag_tr,3];
+		_unit addmagazines [_glmag,6];
+		_unit addmagazines [_glsmokewhite,1];
+		_unit addmagazines [_glsmokered,1];
+		_unit addweapon _glrifle;					//_ftlrifle
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,2];
+		_unit addmagazines [_smokegrenadegreen,2];
+		_unit addWeapon "Rangefinder";
+		_unit linkItem "ItemGPS";
+		["g"] call _backpack;
+	};
+
+
+// LOADOUT: AUTOMATIC RIFLEMAN
+	case "ar":
+	{
+		_unit addmagazines [_ARmag,2];
+		_unit addweapon _AR;
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,1];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		_unit addmagazines [_pistolmag,5];
+		_unit addweapon _pistol;
+		_unit addWeapon "Rangefinder";
+		["ar"] call _backpack;
+	};
+
+// LOADOUT: ASSISTANT AUTOMATIC RIFLEMAN
+	case "aar":
+	{
+		_unit addmagazines [_riflemag,4];
+		_unit addmagazines [_riflemag_tr,3];
+		_unit addweapon _rifle;
+		_unit addmagazines [_grenade,3];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,5];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		_unit addmagazines [_smokegrenadegreen,1];
+		["aar"] call _backpack;
+	};
+
+// LOADOUT: RIFLEMAN (AT)
+	case "rat":
+	{
+		_unit addmagazines [_carbinemag,4];
+		_unit addmagazines [_carbinemag_tr,3];
+		_unit addweapon _carbine;
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,1];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		_unit addmagazines [_smokegrenadegreen,1];
+		["rat"] call _backpack;
+		_unit addweapon _RAT;
+	};
+
+// LOADOUT: DESIGNATED MARKSMAN
+	case "dm":
+	{
+		_unit addmagazines [_DMriflemag,7];
+		_unit addweapon _DMrifle;
+		_unit addmagazines [_grenade,2];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,3];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,2];
+		_unit addmagazines [_pistolmag,3];
+		_unit addweapon _pistol;
+		["dm"] call _backpack;
+		_attachments = [_attach1,_scope2];
+	};
+
+// LOADOUT: MEDIUM MG GUNNER
+	case "mmgg":
+	{
+		_unit addmagazines [_MMGmag,1];
+		_unit addweapon _MMG;
+		_unit addmagazines [_MMGmag,2];
+		_unit addmagazines [_smokegrenade,2];
+		_unit addmagazines [_pistolmag,4];
+		_unit addweapon _pistol;
+		["mmg"] call _backpack;
+		_attachments pushback (_bipod1);
+	};
+
+// LOADOUT: MEDIUM MG ASSISTANT GUNNER
+	case "mmgag":
+	{
+		_unit addmagazines [_riflemag,7];
+		_unit addmagazines [_riflemag_tr,2];
+		_unit addweapon _rifle;
+		_unit addWeapon "Rangefinder";
+		_unit addmagazines [_grenade,2];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,3];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,2];
+		["mmgag"] call _backpack;
+	};
+
+// LOADOUT: HEAVY MG GUNNER
+	case "hmgg":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		["hmgg"] call _backpack;
+	};
+
+// LOADOUT: HEAVY MG ASSISTANT GUNNER
+	case "hmgag":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addWeapon "Rangefinder";
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		["hmgag"] call _backpack;
+	};
+
+// LOADOUT: MEDIUM AT GUNNER
+	case "matg":
+	{
+		["matg"] call _backpack;
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addmagazines [_smokegrenade,2];
+		_unit addweapon _carbine;
+		_unit addweapon _MAT;
+	};
+
+// LOADOUT: MEDIUM AT ASSISTANT GUNNER
+	case "matag":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addWeapon "Rangefinder";
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,2];
+		["matag"] call _backpack;
+	};
+
+// LOADOUT: HEAVY AT GUNNER
+	case "hatg":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addweapon _carbine;
+		["hatg"] call _backpack;
+		_unit addweapon _HAT;
+	};
+
+// LOADOUT: HEAVY AT ASSISTANT GUNNER
+	case "hatag":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addWeapon "Rangefinder";
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		["hatag"] call _backpack;
+	};
+
+// LOADOUT: MORTAR GUNNER
+	case "mtrg":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		["mtrg"] call _backpack;
+	};
+
+// LOADOUT: MORTAR ASSISTANT GUNNER
+	case "mtrag":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		_unit addWeapon "Rangefinder";
+		["mtrag"] call _backpack;
+	};
+
+// LOADOUT: MEDIUM SAM GUNNER
+	case "msamg":
+	{
+		["msamg"] call _backpack;
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addmagazines [_smokegrenade,1];
+		_unit addmagazines [_grenade,1];
+		_unit addweapon _SAM;
+	};
+
+// LOADOUT: MEDIUM SAM ASSISTANT GUNNER
+	case "msamag":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addWeapon "Rangefinder";
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		["msamag"] call _backpack;
+	};
+
+// LOADOUT: HEAVY SAM GUNNER
+	case "hsamg":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		["hsamg"] call _backpack;
+	};
+
+// LOADOUT: HEAVY SAM ASSISTANT GUNNER
+	case "hsamag":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addWeapon "Rangefinder";
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		["hsamag"] call _backpack;
+	};
+
+
+// LOADOUT: SNIPER
+	case "sn":
+	{
+		_unit addmagazines [_SNrifleMag,9];
+		_unit addweapon _SNrifle;
+		_unit addmagazines [_pistolmag,4];
+		_unit addweapon _pistol;
+		_unit addmagazines [_smokegrenade,2];
+		_attachments = [_scope3,_bipod2];
+	};
+
+// LOADOUT: SPOTTER
+	case "sp":
+	{
+		_unit addmagazines [_glriflemag,7];
+		_unit addmagazines [_glriflemag_tr,2];
+		_unit addmagazines [_glmag,2];
+		_unit addmagazines [_glsmokewhite,2];
+		_unit addweapon _glrifle;					//_COrifle
+		_unit addmagazines [_smokegrenade,2];
+		_unit addWeapon "Rangefinder";
+		_unit linkItem "ItemGPS";
+	};
+
+// LOADOUT: VEHICLE COMMANDER
+	case "vc":
+	{
+		_unit addmagazines [_smgmag,5];
+		_unit addweapon _smg;
+		_unit addmagazines [_smokegrenade,2];
+		_unit addItem "ItemGPS";
+		_unit assignItem "ItemGPS";
+		_unit addWeapon "Rangefinder";
+	};
+
+// LOADOUT: VEHICLE DRIVER
+	case "vd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addmagazines [_smgmag,5];
+		_unit addweapon _smg;
+		_unit addmagazines [_smokegrenade,2];
+		_unit addItem "ItemGPS";
+		_unit assignItem "ItemGPS";
+		["cc"] call _backpack;
+	};
+
+// LOADOUT: VEHICLE GUNNER
+	case "vg":
+	{
+		_unit addmagazines [_smgmag,5];
+		_unit addweapon _smg;
+		_unit addmagazines [_smokegrenade,2];
+		_unit addItem "ItemGPS";
+		_unit assignItem "ItemGPS";
+	};
+
+// LOADOUT: AIR VEHICLE PILOTS
+	case "pp":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addmagazines [_smgmag,5];
+		_unit addweapon _smg;
+		_unit addmagazines [_smokegrenade,2];
+		_unit addItem "ItemGPS";
+		_unit assignItem "ItemGPS";
+	};
+
+// LOADOUT: AIR VEHICLE CREW CHIEF
+	case "pcc":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addmagazines [_smgmag,5];
+		_unit addweapon _smg;
+		_unit addmagazines [_smokegrenade,2];
+		["cc"] call _backpack;
+	};
+
+// LOADOUT: AIR VEHICLE CREW
+	case "pc":
+	{
+		_unit addmagazines [_smgmag,5];
+		_unit addweapon _smg;
+		_unit addmagazines [_smokegrenade,2];
+	};
+
+// LOADOUT: ENGINEER (DEMO)
+	case "eng":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addweapon _carbine;
+		_unit addmagazines [_smokegrenade,2];
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_satchel,2];
+		_unit addItem "MineDetector";
+		["eng"] call _backpack;
+	};
+
+// LOADOUT: ENGINEER (MINES)
+	case "engm":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addweapon _carbine;
+		_unit addmagazines [_smokegrenade,2];
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_APmine2,2];
+		_unit addItem "MineDetector";
+		["engm"] call _backpack;
+	};
+
+// LOADOUT: UAV OPERATOR
+	case "uav":
+	{
+		_unit addmagazines [_carbinemag,5];
+		_unit addweapon _carbine;
+		_unit addmagazines [_smokegrenade,2];
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit linkItem _uavterminal;
+		["uav"] call _backpack;
+	};
+
+// LOADOUT: Diver
+	case "div":
+	{
+		_unit addmagazines [_diverMag1,4];
+		_unit addmagazines [_diverMag2,3];
+		_unit addweapon _diverWep;
+		_unit addmagazines [_grenade,3];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,5];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,3];
+		_attachments = [_attach1,_scope1,_silencer1];
+		["div"] call _backpack;
+	};
+
+// LOADOUT: RIFLEMAN
+	case "r":
+	{
+		_unit addmagazines [_riflemag,7];
+		_unit addmagazines [_riflemag_tr,2];
+		_unit addweapon _rifle;
+		_unit addmagazines [_grenade,3];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,5];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,3];
+		["r"] call _backpack;
+	};
+
+// LOADOUT: CARABINEER
+	case "car":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addmagazines [_grenade,3];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,5];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,3];
+		["car"] call _backpack;
+	};
+
+// LOADOUT: SUBMACHINEGUNNER
+	case "smg":
+	{
+		_unit addmagazines [_smgmag,7];
+		_unit addweapon _smg;
+		_unit addmagazines [_grenade,3];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,5];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,3];
+		["smg"] call _backpack;
+	};
+
+// LOADOUT: GRENADIER
+	case "gren":
+	{
+		_unit addmagazines [_glriflemag,4];
+		_unit addmagazines [_glriflemag_tr,3];
+		_unit addmagazines [_glmag,6];
+		_unit addmagazines [_glsmokewhite,1];
+		_unit addmagazines [_glsmokered,1];
+		_unit addweapon _glrifle;					//_ftlrifle
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,2];
+		_unit addmagazines [_smokegrenadegreen,2];
+		_unit addWeapon "Rangefinder";
+		_unit linkItem "ItemGPS";
+		["g"] call _backpack;
+	};
+
+#include "f_assignGear_csat_v.sqf";
+
+// LOADOUT: DEFAULT/UNDEFINED (use RIFLEMAN)
+   default
+   {
+		_unit addmagazines [_riflemag,7];
+		_unit addweapon _rifle;
+
+		_unit selectweapon primaryweapon _unit;
+
+		if (true) exitwith {player globalchat format ["DEBUG (f\assignGear\f_assignGear_csat.sqf): Unit = %1. Gear template %2 does not exist, used Rifleman instead.",_unit,_typeofunit]};
+   };
+
+
+// ====================================================================================
+
+// END SWITCH FOR DEFINE UNIT TYPE LOADOUTS
+};
+
+// ====================================================================================
+
+// If this is an ammobox, check medical component settings and if needed run converter script.
+
+if (!_isMan) then
+	{
+	// Authentic Gameplay Modification
+	if (f_param_medical == 2) exitWith
+		{
+			[_unit] execVM "f\medical\AGM_converter.sqf";
+		};
+	};
+
+// ====================================================================================
+
+// If this isn't run on an infantry unit we can exit
+if !(_isMan) exitWith {};
+
+// ====================================================================================
+
+// Handle weapon attachments
+#include "f_assignGear_attachments.sqf";
+
+// ====================================================================================
+
+// ENSURE UNIT HAS CORRECT WEAPON SELECTED ON SPAWNING
+
+_unit selectweapon primaryweapon _unit;

--- a/f/assignGear/f_assignGear_natopacific.sqf
+++ b/f/assignGear/f_assignGear_natopacific.sqf
@@ -1,0 +1,917 @@
+// F3 - Folk ARPS Assign Gear Script - NATO
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+// ====================================================================================
+
+// DEFINE EQUIPMENT TABLES
+// The blocks of code below identifies equipment for this faction
+//
+// Defined loadouts:
+//		co			- commander
+//		dc 			- deputy commander / squad leader
+//		m 			- medic
+//		ftl			- fire team leader
+//		ar 			- automatic rifleman
+//		aar			- assistant automatic rifleman
+//		rat			- rifleman (AT)
+//		dm			- designated marksman
+//		mmgg		- medium mg gunner
+//		mmgag		- medium mg assistant
+//		matg		- medium AT gunner
+//		matag		- medium AT assistant
+//		hmgg		- heavy mg gunner (deployable)
+//		hmgag		- heavy mg assistant (deployable)
+//		hatg		- heavy AT gunner (deployable)
+//		hatag		- heavy AT assistant (deployable)
+//		mtrg		- mortar gunner (deployable)
+//		mtrag		- mortar assistant (deployable)
+//		msamg		- medium SAM gunner
+//		msamag		- medium SAM assistant gunner
+//		hsamg		- heavy SAM gunner (deployable)
+//		hsamag		- heavy SAM assistant gunner (deployable)
+//		sn			- sniper
+//		sp			- spotter (for sniper)
+//		vc			- vehicle commander
+//		vg			- vehicle gunner
+//		vd			- vehicle driver (repair)
+//		pp			- air vehicle pilot / co-pilot
+//		pcc			- air vehicle co-pilot (repair) / crew chief (repair)
+//		pc			- air vehicle crew
+//		eng			- engineer (demo)
+//		engm		- engineer (mines)
+//		uav			- UAV operator"
+//		div    		- divers
+//
+//		r 			- rifleman
+//		car			- carabineer
+//		smg			- submachinegunner
+//		gren		- grenadier
+//
+//		v_car		- car/4x4
+//		v_tr		- truck
+//		v_ifv		- ifv
+//
+//		crate_small	- small ammocrate
+//		crate_med	- medium ammocrate
+//		crate_large	- large ammocrate
+//
+// ====================================================================================
+
+// GENERAL EQUIPMENT USED BY MULTIPLE CLASSES
+
+// ATTACHMENTS - PRIMARY
+_attach1 = "acc_pointer_IR";	// IR Laser
+_attach2 = "acc_flashlight";	// Flashlight
+
+_silencer1 = "muzzle_snds_M";	// 5.56 suppressor
+_silencer2 = "muzzle_snds_H";	// 6.5 suppressor
+
+_scope1 = "optic_Holosight";	// Basic Scope
+_scope2 = "optic_MRCO";			// MRCO Scope - 1x - 6x
+_scope3 = "optic_SOS";			// SOS Scope - 18x - 75x
+
+_bipod1 = "bipod_01_F_snd";		// Default bipod
+_bipod2 = "bipod_02_F_blk";		// Black bipod
+
+// Default setup
+_attachments = [_attach1,_scope1]; // The default attachment set for most units, overwritten in the individual unitType
+
+// [] = remove all
+// [_attach1,_scope1,_silencer] = remove all, add items assigned in _attach1, _scope1 and _silencer1
+// [_scope2] = add _scope2, remove rest
+// false = keep attachments as they are
+
+// ====================================================================================
+
+// ATTACHMENTS - HANDGUN
+_hg_silencer1 = "muzzle_snds_acp";	// .45 suppressor
+
+_hg_scope1 = "optic_MRD";			// MRD
+
+// Default setup
+_hg_attachments= []; // The default attachment set for handguns, overwritten in the individual unitType
+
+// ====================================================================================
+
+// WEAPON SELECTION
+
+// Standard Riflemen ( MMG Assistant Gunner, Assistant Automatic Rifleman, MAT Assistant Gunner, MTR Assistant Gunner, Rifleman)
+_rifle = "arifle_MX_pointer_F";
+_riflemag = "30Rnd_65x39_caseless_mag";
+_riflemag_tr = "30Rnd_65x39_caseless_mag_Tracer";
+
+// Standard Carabineer (Medic, Rifleman (AT), MAT Gunner, MTR Gunner, Carabineer)
+_carbine = "arifle_MXC_F";
+_carbinemag = "30Rnd_65x39_caseless_mag";
+_carbinemag_tr = "30Rnd_65x39_caseless_mag_Tracer";
+
+// Standard Submachine Gun/Personal Defence Weapon (Aircraft Pilot, Submachinegunner)
+_smg = "SMG_01_F";
+_smgmag = "30Rnd_45ACP_Mag_SMG_01";
+_smgmag_tr = "30Rnd_45ACP_Mag_SMG_01_tracer_green";
+
+// Diver
+_diverWep = "arifle_SDAR_F";
+_diverMag1 = "30Rnd_556x45_Stanag";
+_diverMag2 = "20Rnd_556x45_UW_mag";
+
+// Rifle with GL and HE grenades (CO, DC, FTLs)
+_glrifle = "arifle_MX_GL_F";
+_glriflemag = "30Rnd_65x39_caseless_mag";
+_glriflemag_tr = "30Rnd_65x39_caseless_mag_Tracer";
+_glmag = "1Rnd_HE_Grenade_shell";		// Ideal for Adversarial - Do not use with 3 Round version
+//_glmag = "3Rnd_HE_Grenade_shell";		// Ideal for Co-op - Do not use with 1 Round version
+
+// Smoke for FTLs, Squad Leaders, etc
+_glsmokewhite = "3Rnd_Smoke_Grenade_shell";
+_glsmokegreen = "3Rnd_SmokeGreen_Grenade_shell";
+_glsmokered = "3Rnd_SmokeRed_Grenade_shell";
+
+// Flares for FTLs, Squad Leaders, etc
+_glflarewhite = "3Rnd_UGL_FlareWhite_F";
+_glflarered = "3Rnd_UGL_FlareRed_F";
+_glflareyellow = "3Rnd_UGL_FlareYellow_F";
+_glflaregreen = "3Rnd_UGL_FlareGreen_F";
+
+// Pistols (CO, DC, Automatic Rifleman, Medium MG Gunner)
+_pistol = "hgun_P07_F";
+_pistolmag = "16Rnd_9x21_Mag";
+
+// Grenades
+_grenade = "HandGrenade";
+_Mgrenade = "MiniGrenade";
+_smokegrenade = "SmokeShell";
+_smokegrenadegreen = "SmokeShellGreen";
+
+// misc medical items.
+_firstaid = "FirstAidKit";
+_medkit = "Medikit";
+
+// Night Vision Goggles (NVGoggles)
+_nvg = "NVGoggles";
+
+// UAV Terminal
+_uavterminal = "B_UavTerminal";	  // BLUFOR - FIA
+
+// Chemlights
+_chemgreen =  "Chemlight_green";
+_chemred = "Chemlight_red";
+_chemyellow =  "Chemlight_yellow";
+_chemblue = "Chemlight_blue";
+
+// Backpacks
+_bagsmall = "B_AssaultPack_mcamo";			// carries 120, weighs 20
+_bagmedium = "B_FieldPack_khk";			// carries 240, weighs 30
+_baglarge =  "B_Carryall_mcamo"; 			// carries 320, weighs 40
+_bagmediumdiver =  "B_AssaultPack_blk";		// used by divers
+_baguav = "B_UAV_01_backpack_F";			// used by UAV operator
+_baghmgg = "B_HMG_01_weapon_F";			// used by Heavy MG gunner
+_baghmgag = "B_HMG_01_support_F";			// used by Heavy MG assistant gunner
+_baghatg = "B_AT_01_weapon_F";			// used by Heavy AT gunner
+_baghatag = "B_HMG_01_support_F";			// used by Heavy AT assistant gunner
+_bagmtrg = "B_Mortar_01_weapon_F";			// used by Mortar gunner
+_bagmtrag = "B_Mortar_01_support_F";		// used by Mortar assistant gunner
+_baghsamg = "B_AA_01_weapon_F";			// used by Heavy SAM gunner
+_baghsamag = "B_HMG_01_support_F";			// used by Heavy SAM assistant gunner
+
+// ====================================================================================
+
+// UNIQUE, ROLE-SPECIFIC EQUIPMENT
+
+// Automatic Rifleman
+_AR = "arifle_MX_SW_F";
+_ARmag = "100Rnd_65x39_caseless_mag";
+_ARmag_tr = "100Rnd_65x39_caseless_mag_Tracer";
+
+// Medium MG
+_MMG = "MMG_02_sand_F";
+_MMGmag = "130Rnd_338_Mag";
+_MMGmag_tr = "130Rnd_338_Mag";
+
+// NON-DLC ALTERNATIVE:
+// _MMG = "LMG_Zafir_F";
+// _MMGmag = ""150Rnd_762x54_Box"";
+// _MMGmag_tr = ""150Rnd_762x54_Box"_Tracer";
+
+// Marksman rifle
+_DMrifle = "srifle_DMR_03_tan_F";
+_DMriflemag = "20Rnd_762x51_Mag";
+
+// MAR-10
+//_DMrifle = "srifle_DMR_02_F";
+//_DMriflemag = "10Rnd_338_Mag";
+
+// NON-DLC ALTERNATIVE:
+// _MMG = "LMG_Zafir_F";
+// _MMGmag = "150Rnd_762x51_Box";
+// _MMGmag_tr = "150Rnd_762x51_Box_Tracer";
+
+// Marksman rifle
+_DMrifle = "srifle_EBR_F"; //TODO: EMR-1
+_DMriflemag = "20Rnd_762x51_Mag";
+
+// Rifleman AT
+_RAT = "launch_NLAW_F";
+_RATmag = "NLAW_F";
+
+// Medium AT
+_MAT = "launch_NLAW_F";
+_MATmag1 = "NLAW_F";
+_MATmag2 = "NLAW_F";
+
+// Surface Air
+_SAM = "launch_B_Titan_F";
+_SAMmag = "Titan_AA";
+
+// Heavy AT
+_HAT = "launch_B_Titan_short_F";
+_HATmag1 = "Titan_AT";
+_HATmag2 = "Titan_AP";
+
+// Sniper
+_SNrifle = "srifle_LRR_F";
+_SNrifleMag = "7Rnd_408_Mag";
+
+// Engineer items
+_ATmine = "ATMine_Range_Mag";
+_satchel = "DemoCharge_Remote_Mag";
+_APmine1 = "APERSBoundingMine_Range_Mag";
+_APmine2 = "APERSMine_Range_Mag";
+
+// ====================================================================================
+
+// CLOTHES AND UNIFORMS
+
+// Define classes. This defines which gear class gets which uniform
+// "medium" vests are used for all classes if they are not assigned a specific uniform
+
+_light = [];
+_heavy =  ["eng","engm"];
+_diver = ["div"];
+_pilot = ["pp","pcc","pc"];
+_crew = ["vc","vg","vd"];
+_ghillie = ["sn","sp"];
+_specOp = [];
+
+// Basic clothing
+// The outfit-piece is randomly selected from the array for each unit
+_baseUniform = ["U_B_CombatUniform_mcam","U_B_CombatUniform_mcam_tshirt","U_B_CombatUniform_mcam_vest"];
+_baseHelmet = ["H_HelmetB","H_HelmetB_plain_mcamo"];
+_baseGlasses = [];
+
+// Armored vests
+_lightRig = ["V_TacVest_blk","V_TacVest_brn","V_TacVest_camo","V_TacVest_oli"];
+_mediumRig = ["V_PlateCarrier1_rgr","V_PlateCarrier2_rgr"]; 	// default for all infantry classes
+_heavyRig = ["V_PlateCarrier3_rgr"];
+
+// Diver
+_diverUniform =  ["U_B_Wetsuit"];
+_diverHelmet = [];
+_diverRig = ["V_RebreatherB"];
+_diverGlasses = ["G_Diving"];
+
+// Pilot
+_pilotUniform = ["U_B_HeliPilotCoveralls"];
+_pilotHelmet = ["H_PilotHelmetHeli_B"];
+_pilotRig = ["V_TacVest_blk"];
+_pilotGlasses = [];
+
+// Crewman
+_crewUniform = ["U_B_CombatUniform_mcam_vest"];
+_crewHelmet = ["H_HelmetCrew_B"];
+_crewRig = ["V_TacVest_blk"];
+_crewGlasses = [];
+
+// Ghillie
+_ghillieUniform = ["U_B_GhillieSuit"]; //DLC alternatives: ["U_B_FullGhillie_lsh","U_B_FullGhillie_ard","U_B_FullGhillie_sard"];
+_ghillieHelmet = [];
+_ghillieRig = ["V_Chestrig_rgr"];
+_ghillieGlasses = [];
+
+// Spec Op
+_sfuniform = ["U_B_SpecopsUniform_sgg"];
+_sfhelmet = ["H_HelmetSpecB","H_HelmetSpecB_paint1","H_HelmetSpecB_paint2","H_HelmetSpecB_blk"];
+_sfRig = ["V_PlateCarrierSpec_rgr"];
+_sfGlasses = [];
+
+// ====================================================================================
+
+// INTERPRET PASSED VARIABLES
+// The following inrerprets formats what has been passed to this script element
+
+_typeofUnit = toLower (_this select 0);			// Tidy input for SWITCH/CASE statements, expecting something like : r = Rifleman, co = Commanding Officer, rat = Rifleman (AT)
+_unit = _this select 1;					// expecting name of unit; originally passed by using 'this' in unit init
+_isMan = _unit isKindOf "CAManBase";	// We check if we're dealing with a soldier or a vehicle
+
+// ====================================================================================
+
+// This block needs only to be run on an infantry unit
+if (_isMan) then {
+
+		// PREPARE UNIT FOR GEAR ADDITION
+	// The following code removes all existing weapons, items, magazines and backpacks
+
+	removeBackpack _unit;
+	removeAllWeapons _unit;
+	removeAllItemsWithMagazines _unit;
+	removeAllAssignedItems _unit;
+
+	// ====================================================================================
+
+	// HANDLE CLOTHES
+	// Handle clothes and helmets and such using the include file called next.
+
+	#include "f_assignGear_clothes.sqf";
+
+	// ====================================================================================
+
+	// ADD UNIVERSAL ITEMS
+	// Add items universal to all units of this faction
+
+	_unit linkItem _nvg;			// Add and equip the faction's nvg
+	_unit addItem _firstaid;		// Add a single first aid kit (FAK)
+	_unit linkItem "ItemMap";		// Add and equip the map
+	_unit linkItem "ItemCompass";	// Add and equip a compass
+	_unit linkItem "ItemRadio";		// Add and equip A3's default radio
+	_unit linkItem "ItemWatch";		// Add and equip a watch
+	_unit linkItem "ItemGPS"; 	// Add and equip a GPS
+
+};
+
+
+// ====================================================================================
+
+// SETUP BACKPACKS
+// Include the correct backpack file for the faction
+
+_backpack = {
+	_typeofBackPack = _this select 0;
+	_loadout = f_param_backpacks;
+	if (count _this > 1) then {_loadout = _this select 1};
+	switch (_typeofBackPack) do
+	{
+		#include "f_assignGear_nato_b.sqf";
+	};
+};
+
+// ====================================================================================
+
+// DEFINE UNIT TYPE LOADOUTS
+// The following blocks of code define loadouts for each type of unit (the unit type
+// is passed to the script in the first variable)
+
+switch (_typeofUnit) do
+{
+
+// ====================================================================================
+
+// LOADOUT: COMMANDER
+	case "co":
+	{
+		_unit addmagazines [_glriflemag,1];
+		_unit addmagazines [_glriflemag_tr,3];
+		_unit addmagazines [_glsmokered,1];
+		_unit addmagazines [_glflareyellow,2];
+		_unit addweapon _glrifle;				//_COrifle
+		_unit addmagazines [_pistolmag,4];
+		_unit addweapon _pistol;
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,1];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		_unit addmagazines [_smokegrenadegreen,1];
+		_unit addWeapon "Rangefinder";
+		_unit linkItem "ItemGPS";
+		["g"] call _backpack;
+	};
+
+// LOADOUT: DEPUTY COMMANDER AND SQUAD LEADER
+	case "dc":
+	{
+		_unit addmagazines [_glriflemag,1];
+		_unit addmagazines [_glriflemag_tr,3];
+		//_unit addmagazines [_glmag,1];			// Use with 3 Rnd. UGL mags
+		_unit addmagazines [_glmag,3];			// Use with 1 Rnd. UGL mags
+		_unit addmagazines [_glsmokered,1];
+		_unit addmagazines [_glflareyellow,1];
+		_unit addweapon _glrifle;				//_DC & _SLrifle
+		_unit addmagazines [_pistolmag,4];
+		_unit addweapon _pistol;
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,1];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		_unit addmagazines [_smokegrenadegreen,1];
+		_unit addWeapon "Rangefinder";
+		_unit linkItem "ItemGPS";
+		["g"] call _backpack;
+	};
+
+// LOADOUT: JTAC
+	case "jtac":
+	{
+		_unit addmagazines [_glriflemag,1];
+		_unit addmagazines [_glsmokered,3];
+		_unit addmagazines [_glflareyellow,1];
+		_unit addweapon _glrifle;				//_JTACrifle
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,1];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		_unit addmagazines [_smokegrenadegreen,1];
+		_unit addMagazines ["Laserbatteries",1];
+		_unit addWeapon "Laserdesignator";
+		_unit linkItem "ItemGPS";
+		["g"] call _backpack;
+	};
+
+// LOADOUT: MEDIC
+	case "m":
+	{
+		_unit addmagazines [_carbinemag,9];
+		_unit addweapon _carbine;
+		_unit addmagazines [_smokegrenade,4];
+		{_unit addItem _firstaid} forEach [1,2,3,4];
+		_unit linkItem "ItemGPS";
+		["m"] call _backpack;
+	};
+
+// LOADOUT: FIRETEAM LEADER
+	case "ftl":
+	{
+		_unit addmagazines [_glriflemag,4];
+		_unit addmagazines [_glriflemag_tr,3];
+		//_unit addmagazines [_glmag,2];			// Use with 3 Rnd. UGL mags
+		_unit addmagazines [_glmag,6];			// Use with 1 Rnd. UGL mags
+		_unit addmagazines [_glsmokewhite,1];
+		_unit addweapon _glrifle;				//_ftlrifle
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,2];
+		_unit addmagazines [_smokegrenadegreen,2];
+		_unit addWeapon "Rangefinder";
+		_unit linkItem "ItemGPS";
+		["g"] call _backpack;
+	};
+
+
+// LOADOUT: AUTOMATIC RIFLEMAN
+	case "ar":
+	{
+		_unit addmagazines [_ARmag,4];
+		_unit addweapon _AR;
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,1];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		_unit addmagazines [_pistolmag,5];
+		_unit addweapon _pistol;
+		_unit addWeapon "Rangefinder";
+		["ar"] call _backpack;
+		_attachments pushback (_bipod1);
+	};
+
+// LOADOUT: JUNIOR RIFLEMAN
+	case "aar":
+	{
+		_unit addmagazines [_riflemag,4];
+		_unit addmagazines [_riflemag_tr,3];
+		_unit addweapon _rifle;
+		_unit addmagazines [_grenade,3];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,5];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		_unit addmagazines [_smokegrenadegreen,1];
+		["aar"] call _backpack;
+	};
+
+// LOADOUT: RIFLEMAN (AT)
+	case "rat":
+	{
+		_unit addmagazines [_carbinemag,4];
+		_unit addmagazines [_carbinemag_tr,3];
+		_unit addweapon _carbine;
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,1];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,1];
+		_unit addmagazines [_smokegrenadegreen,1];
+		["rat"] call _backpack;
+		_unit addweapon _RAT;
+	};
+
+// LOADOUT: DESIGNATED MARKSMAN
+	case "dm":
+	{
+		_unit addmagazines [_DMriflemag,7];
+		_unit addweapon _DMrifle;
+		_unit addmagazines [_grenade,2];
+		_unit addmagazines [_mgrenade,2];
+		_unit addmagazines [_smokegrenade,2];
+		_unit addmagazines [_pistolmag,3];
+		_unit addweapon _pistol;
+		["dm"] call _backpack;
+		_attachments = [_attach1,_scope2];
+	};
+
+// LOADOUT: MEDIUM MG GUNNER
+	case "mmgg":
+	{
+		_unit addmagazines [_MMGmag,1];
+		_unit addweapon _MMG;
+		_unit addmagazines [_MMGmag,2];
+		_unit addmagazines [_smokegrenade,2];
+		_unit addmagazines [_pistolmag,4];
+		_unit addweapon _pistol;
+		["mmg"] call _backpack;
+		_attachments pushback (_bipod1);
+	};
+
+// LOADOUT: MEDIUM MG ASSISTANT GUNNER
+	case "mmgag":
+	{
+		_unit addmagazines [_riflemag,7];
+		_unit addmagazines [_riflemag_tr,2];
+		_unit addweapon _rifle;
+		_unit addWeapon "Rangefinder";
+		_unit addmagazines [_grenade,2];
+		_unit addmagazines [_mgrenade,2];
+		_unit addmagazines [_smokegrenade,2];
+		["mmgag"] call _backpack;
+	};
+
+// LOADOUT: HEAVY MG GUNNER
+	case "hmgg":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addmagazines [_grenade,1];
+		_unit addmagazines [_mgrenade,1];
+		_unit addmagazines [_smokegrenade,1];
+		["hmgg"] call _backpack;
+	};
+
+// LOADOUT: HEAVY MG ASSISTANT GUNNER
+	case "hmgag":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addWeapon "Rangefinder";
+		_unit addmagazines [_grenade,1];
+		_unit addmagazines [_mgrenade,1];
+		_unit addmagazines [_smokegrenade,1];
+		["hmgag"] call _backpack;
+	};
+
+// LOADOUT: MEDIUM AT GUNNER
+	case "matg":
+	{
+		["matg"] call _backpack;
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addmagazines [_smokegrenade,2];
+		_unit addweapon _carbine;
+		_unit addweapon _MAT;
+	};
+
+// LOADOUT: MEDIUM AT ASSISTANT GUNNER
+	case "matag":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addWeapon "Rangefinder";;
+		_unit addmagazines [_grenade,1];
+		_unit addmagazines [_mgrenade,1];
+		_unit addmagazines [_smokegrenade,2];
+		["matag"] call _backpack;
+	};
+
+// LOADOUT: HEAVY AT GUNNER
+	case "hatg":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addweapon _carbine;
+		["hatg"] call _backpack;
+		_unit addweapon _HAT;
+	};
+
+// LOADOUT: HEAVY AT ASSISTANT GUNNER
+	case "hatag":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addWeapon "Rangefinder";
+		_unit addmagazines [_grenade,1];
+		_unit addmagazines [_mgrenade,1];
+		_unit addmagazines [_smokegrenade,1];
+		["hatag"] call _backpack;
+	};
+
+// LOADOUT: MORTAR GUNNER
+	case "mtrg":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addmagazines [_grenade,1];
+		_unit addmagazines [_mgrenade,1];
+		_unit addmagazines [_smokegrenade,1];
+		["mtrg"] call _backpack;
+	};
+
+// LOADOUT: MORTAR ASSISTANT GUNNER
+	case "mtrag":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addmagazines [_grenade,1];
+		_unit addmagazines [_mgrenade,1];
+		_unit addmagazines [_smokegrenade,1];
+		_unit addWeapon "Rangefinder";
+		["mtrag"] call _backpack;
+	};
+
+// LOADOUT: MEDIUM SAM GUNNER
+	case "msamg":
+	{
+		["msamg"] call _backpack;
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addmagazines [_smokegrenade,1];
+		_unit addmagazines [_grenade,1];
+		_unit addweapon _SAM;
+	};
+
+// LOADOUT: MEDIUM SAM ASSISTANT GUNNER
+	case "msamag":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addWeapon "Rangefinder";
+		_unit addmagazines [_grenade,1];
+		_unit addmagazines [_smokegrenade,1];
+		["msamag"] call _backpack;
+	};
+
+// LOADOUT: HEAVY SAM GUNNER
+	case "hsamg":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addmagazines [_grenade,1];
+		_unit addmagazines [_mgrenade,1];
+		_unit addmagazines [_smokegrenade,1];
+		["hsamg"] call _backpack;
+	};
+
+// LOADOUT: HEAVY SAM ASSISTANT GUNNER
+	case "hsamag":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addWeapon "Rangefinder";
+		_unit addmagazines [_grenade,1];
+		_unit addmagazines [_mgrenade,1];
+		_unit addmagazines [_smokegrenade,1];
+		["hsamag"] call _backpack;
+	};
+
+// LOADOUT: SNIPER
+	case "sn":
+	{
+		_unit addmagazines [_SNrifleMag,9];
+		_unit addweapon _SNrifle;
+		_unit addmagazines [_pistolmag,4];
+		_unit addweapon _pistol;
+		_unit addmagazines [_smokegrenade,2];
+		_attachments = [_scope3];
+	};
+
+// LOADOUT: SPOTTER
+	case "sp":
+	{
+		_unit addmagazines [_glriflemag,7];
+		_unit addmagazines [_glriflemag_tr,2];
+		_unit addmagazines [_glmag,2];
+		_unit addmagazines [_glsmokewhite,2];
+		_unit addweapon _glrifle;					//_COrifle
+		_unit addmagazines [_smokegrenade,2];
+		_unit addWeapon "Rangefinder";
+		_unit linkItem "ItemGPS";
+	};
+
+// LOADOUT: VEHICLE COMMANDER
+	case "vc":
+	{
+		_unit addmagazines [_smgmag,5];
+		_unit addweapon _smg;
+		_unit addmagazines [_smokegrenade,2];
+		_unit addItem "ItemGPS";
+		_unit assignItem "ItemGPS";
+		_unit addWeapon "Rangefinder";
+	};
+
+// LOADOUT: VEHICLE DRIVER
+	case "vd":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addmagazines [_smgmag,5];
+		_unit addweapon _smg;
+		_unit addmagazines [_smokegrenade,2];
+		_unit addItem "ItemGPS";
+		_unit assignItem "ItemGPS";
+		["cc"] call _backpack;
+	};
+
+// LOADOUT: VEHICLE GUNNER
+	case "vg":
+	{
+		_unit addmagazines [_smgmag,5];
+		_unit addweapon _smg;
+		_unit addmagazines [_smokegrenade,2];
+		_unit addItem "ItemGPS";
+		_unit assignItem "ItemGPS";
+	};
+
+// LOADOUT: AIR VEHICLE PILOTS
+	case "pp":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addmagazines [_smgmag,5];
+		_unit addweapon _smg;
+		_unit addmagazines [_smokegrenade,2];
+		_unit addItem "ItemGPS";
+		_unit assignItem "ItemGPS";
+	};
+
+// LOADOUT: AIR VEHICLE CREW CHIEF
+	case "pcc":
+	{
+		_unit setUnitTrait ["engineer",true]; // Can repair
+		_unit addmagazines [_smgmag,5];
+		_unit addweapon _smg;
+		_unit addmagazines [_smokegrenade,2];
+		["cc"] call _backpack;
+	};
+
+// LOADOUT: AIR VEHICLE CREW
+	case "pc":
+	{
+		_unit addmagazines [_smgmag,5];
+		_unit addweapon _smg;
+		_unit addmagazines [_smokegrenade,2];
+	};
+
+// LOADOUT: ENGINEER (DEMO)
+	case "eng":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addweapon _carbine;
+		_unit addmagazines [_smokegrenade,2];
+		_unit addmagazines [_grenade,1];
+		_unit addmagazines [_mgrenade,1];
+		_unit addmagazines [_satchel,2];
+		_unit addItem "MineDetector";
+		["eng"] call _backpack;
+	};
+
+// LOADOUT: ENGINEER (MINES)
+	case "engm":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addweapon _carbine;
+		_unit addmagazines [_smokegrenade,2];
+		_unit addmagazines [_grenade,1];
+		_unit addmagazines [_mgrenade,1];
+		_unit addmagazines [_APmine2,2];
+		_unit addItem "MineDetector";
+		["engm"] call _backpack;
+	};
+
+// LOADOUT: UAV OPERATOR
+	case "uav":
+	{
+		_unit addmagazines [_carbinemag,5];
+		_unit addweapon _carbine;
+		_unit addmagazines [_smokegrenade,2];
+		_unit addmagazines [_grenade,1];
+		_unit addmagazines [_mgrenade,1];
+		_unit linkItem _uavterminal;
+		["uav"] call _backpack;
+	};
+
+// LOADOUT: Diver
+	case "div":
+	{
+		_unit addmagazines [_diverMag1,4];
+		_unit addmagazines [_diverMag2,3];
+		_unit addweapon _diverWep;
+		_unit addmagazines [_grenade,3];
+		_unit addmagazines [_mgrenade,3];
+		_unit addmagazines [_smokegrenade,3];
+		_attachments = [_attach1,_scope1,_silencer1];
+		["div"] call _backpack;
+	};
+
+// LOADOUT: RIFLEMAN
+	case "r":
+	{
+		_unit addmagazines [_riflemag,7];
+		_unit addmagazines [_riflemag_tr,2];
+		_unit addweapon _rifle;
+		_unit addmagazines [_grenade,3];
+		_unit addmagazines [_mgrenade,3];
+		_unit addmagazines [_smokegrenade,3];
+		["r"] call _backpack;
+	};
+
+// LOADOUT: CARABINEER
+	case "car":
+	{
+		_unit addmagazines [_carbinemag,7];
+		_unit addmagazines [_carbinemag_tr,2];
+		_unit addweapon _carbine;
+		_unit addmagazines [_grenade,3];
+		_unit addmagazines [_mgrenade,3];
+		_unit addmagazines [_smokegrenade,3];
+		["car"] call _backpack;
+	};
+
+// LOADOUT: SUBMACHINEGUNNER
+	case "smg":
+	{
+		_unit addmagazines [_smgmag,7];
+		_unit addweapon _smg;
+		_unit addmagazines [_grenade,3];
+		_unit addmagazines [_mgrenade,3];
+		_unit addmagazines [_smokegrenade,3];
+		["smg"] call _backpack;
+	};
+
+// LOADOUT: GRENADIER
+	case "gren":
+	{
+		_unit addmagazines [_glriflemag,4];
+		_unit addmagazines [_glriflemag_tr,3];
+		//_unit addmagazines [_glmag,2];			// Use with 3 Rnd. UGL mags
+		_unit addmagazines [_glmag,6];			// Use with 1 Rnd. UGL mags
+		_unit addmagazines [_glsmokewhite,1];
+		_unit addweapon _glrifle;				//_grenrifle
+		_unit addmagazines [_grenade,1];		// Do not use with mgrenades
+		//_unit addmagazines [_mgrenade,2];		// Do not use with grenades
+		_unit addmagazines [_smokegrenade,2];
+		_unit addmagazines [_smokegrenadegreen,2];
+		_unit addWeapon "Rangefinder";
+		_unit linkItem "ItemGPS";
+		["g"] call _backpack;
+	};
+
+#include "f_assignGear_nato_v.sqf";
+
+// LOADOUT: DEFAULT/UNDEFINED (use RIFLEMAN)
+   default
+   {
+		_unit addmagazines [_riflemag,7];
+		_unit addweapon _rifle;
+
+		_unit selectweapon primaryweapon _unit;
+
+		if (true) exitwith {player globalchat format ["DEBUG (f\assignGear\f_assignGear_nato.sqf): Unit = %1. Gear template %2 does not exist, used Rifleman instead.",_unit,_typeofunit]};
+   };
+
+
+// ====================================================================================
+
+// END SWITCH FOR DEFINE UNIT TYPE LOADOUTS
+};
+
+// ====================================================================================
+
+// If this is an ammobox, check medical component settings and if needed run converter script.
+
+if (!_isMan) then
+	{
+	// Authentic Gameplay Modification
+	if (f_param_medical == 2) exitWith
+		{
+			[_unit] execVM "f\medical\AGM_converter.sqf";
+		};
+	};
+
+// ====================================================================================
+
+// If this isn't run on an infantry unit we can exit
+if !(_isMan) exitWith {};
+
+// ====================================================================================
+
+// Handle weapon attachments
+#include "f_assignGear_attachments.sqf";
+
+// ====================================================================================
+
+// ENSURE UNIT HAS CORRECT WEAPON SELECTED ON SPAWNING
+
+_unit selectweapon primaryweapon _unit;

--- a/f/assignGear/fn_assignGear.sqf
+++ b/f/assignGear/fn_assignGear.sqf
@@ -27,10 +27,10 @@ _faction = toLower (param[2, (faction _unit)]);
 // Altis and Tanoa. Additionally, CSAT has an urban camo option. The following variables
 // can be changed to apply the desired style of insignia to the NATO and CSAT platoons.
 
-private _insignia_style_NATO = "Altis"; // Options: "Altis" | "Tanoa"
-private _insignia_style_CSAT = "Altis"; // Options: "Altis" | "Tanoa" | "Urban"
+_insignia_style_NATO = "Altis"; // Options: "Altis" | "Tanoa"
+_insignia_style_CSAT = "Altis"; // Options: "Altis" | "Tanoa" | "Urban"
 
-private _insignia_styles = [_insignia_style_NATO,_insignia_style_CSAT];
+_insignia_styles = [_insignia_style_NATO,_insignia_style_CSAT];
 [_unit,_typeofUnit,_insignia_styles] spawn {
 	#include "f_assignInsignia.sqf"
 };

--- a/f/assignGear/fn_assignGear.sqf
+++ b/f/assignGear/fn_assignGear.sqf
@@ -73,16 +73,23 @@ if (f_param_debugMode == 1) then
 
 // ====================================================================================
 
-// ====================================================================================
-
 // GEAR: BLUFOR > NATO
 // The following block of code executes only if the unit belongs to the NATO faction; it
 // automatically includes a file which contains the appropriate equipment data.
 
-if (_faction == "blu_f") then {
+if (_faction in ["blu_f","nato"]) then {
 	#include "f_assignGear_nato.sqf"
 };
 
+// ====================================================================================
+
+// GEAR: BLUFOR > NATO (Pacific)
+// The following block of code executes only if the unit belongs to the NATO (Pacific) faction; it
+// automatically includes a file which contains the appropriate equipment data.
+
+if (_faction in ["blu_t_f","natopacific"]) then {
+	#include "f_assignGear_natopacific.sqf"
+};
 
 // ====================================================================================
 
@@ -90,8 +97,18 @@ if (_faction == "blu_f") then {
 // The following block of code executes only if the unit belongs to the CSAT faction; it
 // automatically includes a file which contains the appropriate equipment data.
 
-if (_faction == "opf_f") then {
+if (_faction in ["opf_f","csat"]) then {
 	#include "f_assignGear_csat.sqf"
+};
+
+// ====================================================================================
+
+// GEAR: OPFOR > CSAT (Pacific)
+// The following block of code executes only if the unit belongs to the CSAT (Pacific) faction; it
+// automatically includes a file which contains the appropriate equipment data.
+
+if (_faction in ["opf_t_f","csatpacific"]) then {
+	#include "f_assignGear_csatpacific.sqf"
 };
 
 // ====================================================================================
@@ -100,27 +117,27 @@ if (_faction == "opf_f") then {
 // The following block of code executes only if the unit belongs to the AAF faction; it
 // automatically includes a file which contains the appropriate equipment data.
 
-if(_faction == "ind_f") then {
+if (_faction in ["ind_f","aaf"]) then {
 	#include "f_assignGear_aaf.sqf"
 };
 
 // ====================================================================================
 
 // GEAR: FIA
-// The following block of code executes only if the unit belongs to the FIA slot (any faction); it
+// The following block of code executes only if the unit belongs to the FIA slot (any side); it
 // automatically includes a file which contains the appropriate equipment data.
 
-if (_faction in ["blu_g_f","opf_g_f","ind_g_f"]) then {
+if (_faction in ["blu_g_f","opf_g_f","ind_g_f","fia"]) then {
 	#include "f_assignGear_fia.sqf"
 };
 
 // ====================================================================================
 
 // GEAR: CTRG
-// The following block of code executes only if the unit is manually assigned the "ctrg" faction; it
+// The following block of code executes only if the unit belongs to the CTRG faction; it
 // automatically includes a file which contains the appropriate equipment data.
 
-if(_faction == "ctrg") then {
+if (_faction in ["","ctrg"]) then {
 	#include "f_assignGear_ctrg.sqf"
 };
 
@@ -130,7 +147,7 @@ if(_faction == "ctrg") then {
 // The following block of code executes only if the unit is manually assigned the Syndikat faction; it
 // automatically includes a file which contains the appropriate equipment data.
 
-if (_faction =="ind_c_f") then {
+if (_faction in ["ind_c_f","syndikat"]) then {
 	#include "f_assignGear_syndikat.sqf"
 };
 

--- a/f/assignGear/fn_assignGear.sqf
+++ b/f/assignGear/fn_assignGear.sqf
@@ -27,10 +27,10 @@ _faction = toLower (param[2, (faction _unit)]);
 // Altis and Tanoa. Additionally, CSAT has an urban camo option. The following variables
 // can be changed to apply the desired style of insignia to the NATO and CSAT platoons.
 
-_insignia_style_NATO = "Altis"; // Options: "Altis" | "Tanoa"
-_insignia_style_CSAT = "Altis"; // Options: "Altis" | "Tanoa" | "Urban"
+private _insignia_style_NATO = "Altis"; // Options: "Altis" | "Tanoa"
+private _insignia_style_CSAT = "Altis"; // Options: "Altis" | "Tanoa" | "Urban"
 
-_insignia_styles = [_insignia_style_NATO,_insignia_style_CSAT];
+private _insignia_styles = [_insignia_style_NATO,_insignia_style_CSAT];
 [_unit,_typeofUnit,_insignia_styles] spawn {
 	#include "f_assignInsignia.sqf"
 };
@@ -54,7 +54,7 @@ _unit setVariable ["f_var_assignGear",_typeofUnit,true];
 // DECLARE VARIABLES AND FUNCTIONS 2
 // Used by the faction-specific scripts
 
-private ["_attach1","_attach2","_silencer1","_silencer2","_scope1","_scope2","_scope3","_bipod1","_bipod2","_attachments","_silencer","_hg_silencer1","_hg_scope1","_hg_attachments","_rifle","_riflemag","_riflemag_tr","_carbine","_carbinemag","_carbinemag_tr","_smg","_smgmag","_smgmag_tr","_diverWep","_diverMag1","_diverMag2","_glrifle","_glriflemag","_glriflemag_tr","_glmag","_glsmokewhite","_glsmokegreen","_glsmokered","_glflarewhite","_glflarered","_glflareyellow","_glflaregreen","_pistol","_pistolmag","_grenade","_Mgrenade","_smokegrenade","_smokegrenadegreen","_firstaid","_medkit","_nvg","_uavterminal","_chemgreen","_chemred","_chemyellow","_chemblue","_bagsmall","_bagmedium","_baglarge","_bagmediumdiver","_baguav","_baghmgg","_baghmgag","_baghatg","_baghatag","_bagmtrg","_bagmtrag","_baghsamg","_baghsamag","_AR","_ARmag","_ARmag_tr","_MMG","_MMGmag","_MMGmag_tr","_Tracer","_DMrifle","_DMriflemag","_RAT","_RATmag","_MAT","_MATmag1","_MATmag2","_HAT","_HATmag1","_HATmag2","_SAM","_SAMmag","_SNrifle","_SNrifleMag","_ATmine","_satchel","_APmine1","_APmine2","_light","_heavy","_diver","_pilot","_crew","_ghillie","_specOp","_baseUniform","_baseHelmet","_baseGlasses","_lightRig","_mediumRig","_heavyRig","_diverUniform","_diverHelmet","_diverRig","_diverGlasses","_pilotUniform","_pilotHelmet","_pilotRig","_pilotGlasses","_crewUniform","_crewHelmet","_crewRig","_crewGlasses","_ghillieUniform","_ghillieHelmet","_ghillieRig","_ghillieGlasses","_sfuniform","_sfhelmet","_sfRig","_sfGlasses","_typeofUnit","_unit","_isMan","_backpack","_typeofBackPack","_loadout","_COrifle","_mgrenade","_DCrifle","_FTLrifle","_armag","_ratmag","_typeofunit"];
+private ["_attach1","_attach2","_silencer1","_silencer2","_scope1","_scope2","_scope3","_bipod1","_bipod2","_attachments","_silencer","_hg_silencer1","_hg_scope1","_hg_attachments","_rifle","_riflemag","_riflemag_tr","_carbine","_carbinemag","_carbinemag_tr","_smg","_smgmag","_smgmag_tr","_diverWep","_diverMag1","_diverMag2","_glrifle","_glriflemag","_glriflemag_tr","_glmag","_glsmokewhite","_glsmokegreen","_glsmokered","_glflarewhite","_glflarered","_glflareyellow","_glflaregreen","_pistol","_pistolmag","_grenade","_Mgrenade","_smokegrenade","_smokegrenadegreen","_firstaid","_medkit","_nvg","_uavterminal","_chemgreen","_chemred","_chemyellow","_chemblue","_bagsmall","_bagmedium","_baglarge","_bagmediumdiver","_baguav","_baghmgg","_baghmgag","_baghatg","_baghatag","_bagmtrg","_bagmtrag","_baghsamg","_baghsamag","_AR","_ARmag","_ARmag_tr","_MMG","_MMGmag","_MMGmag_tr","_Tracer","_DMrifle","_DMriflemag","_RAT","_RATmag","_MAT","_MATmag1","_MATmag2","_SAM","_SAMmag","_HAT","_HATmag1","_HATmag2","_SNrifle","_SNrifleMag","_ATmine","_satchel","_APmine1","_APmine2","_light","_heavy","_diver","_pilot","_crew","_ghillie","_specOp","_baseUniform","_baseHelmet","_baseGlasses","_lightRig","_mediumRig","_heavyRig","_diverUniform","_diverHelmet","_diverRig","_diverGlasses","_pilotUniform","_pilotHelmet","_pilotRig","_pilotGlasses","_crewUniform","_crewHelmet","_crewRig","_crewGlasses","_ghillieUniform","_ghillieHelmet","_ghillieRig","_ghillieGlasses","_sfuniform","_sfhelmet","_sfRig","_sfGlasses","_typeofUnit","_unit","_isMan","_backpack","_typeofBackPack","_loadout","_COrifle","_mgrenade","_DC","_SLrifle","_JTACrifle","_ftlrifle","_grenrifle","_typeofunit"];
 
 // ====================================================================================
 
@@ -137,7 +137,7 @@ if (_faction in ["blu_g_f","opf_g_f","ind_g_f","fia"]) then {
 // The following block of code executes only if the unit belongs to the CTRG faction; it
 // automatically includes a file which contains the appropriate equipment data.
 
-if (_faction in ["","ctrg"]) then {
+if (_faction in ["blu_ctrg_f","ctrg"]) then {
 	#include "f_assignGear_ctrg.sqf"
 };
 

--- a/f/briefing/f_briefing_ctrg.sqf
+++ b/f/briefing/f_briefing_ctrg.sqf
@@ -1,0 +1,81 @@
+// F3 - Briefing
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+// ====================================================================================
+
+// FACTION: CTRG
+
+// ====================================================================================
+
+// NOTES: CREDITS
+// The code below creates the administration sub-section of notes.
+
+_cre = player createDiaryRecord ["diary", ["Credits","
+<br/>
+*** Insert mission credits here. ***
+<br/><br/>
+Made with F3 (http://www.ferstaberinde.com/f3/en/)
+"]];
+
+// ====================================================================================
+
+// NOTES: ADMINISTRATION
+// The code below creates the administration sub-section of notes.
+
+_adm = player createDiaryRecord ["diary", ["Administration","
+<br/>
+*** Insert information on administration and logistics here. ***
+"]];
+
+// ====================================================================================
+
+// NOTES: EXECUTION
+// The code below creates the execution sub-section of notes.
+
+_exe = player createDiaryRecord ["diary", ["Execution","
+<br/>
+<font size='18'>COMMANDER'S INTENT</font>
+<br/>
+*** Insert very short summary of plan here. ***
+<br/><br/>
+<font size='18'>MOVEMENT PLAN</font>
+<br/>
+*** Insert movement instructions here. ***
+<br/><br/>
+<font size='18'>FIRE SUPPORT PLAN</font>
+<br/>
+*** Insert fire support instructions here. ***
+<br/><br/>
+<font size='18'>SPECIAL TASKS</font>
+<br/>
+*** Insert instructions for specific units here. ***
+"]];
+
+// ====================================================================================
+
+// NOTES: MISSION
+// The code below creates the mission sub-section of notes.
+
+_mis = player createDiaryRecord ["diary", ["Mission","
+<br/>
+*** Insert the mission here. ***
+"]];
+
+// ====================================================================================
+
+// NOTES: SITUATION
+// The code below creates the situation sub-section of notes.
+
+_sit = player createDiaryRecord ["diary", ["Situation","
+<br/>
+*** Insert general information about the situation here.***
+<br/><br/>
+<font size='18'>ENEMY FORCES</font>
+<br/>
+*** Insert information about enemy forces here.***
+<br/><br/>
+<font size='18'>FRIENDLY FORCES</font>
+<br/>
+*** Insert information about friendly forces here.***
+"]];
+
+// ====================================================================================

--- a/f/groupMarkers/f_setLocalGroupMarkers.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers.sqf
@@ -62,11 +62,6 @@ _uav = "b_uav";			// UAV
 // Due to the amount of markers the script is split into various sub-scripts (by side)
 // which are now included to create the complete script
 
-switch (_unitfaction) do
-{
-
-// ====================================================================================
-
 // MARKERS: BLUFOR
 // Markers seen by players in BLUFOR slots
 
@@ -87,5 +82,3 @@ switch (_unitfaction) do
 #include "f_setLocalGroupMarkers_Indfor.sqf"
 
 // ====================================================================================
-
-};

--- a/f/groupMarkers/f_setLocalGroupMarkers.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers.sqf
@@ -82,3 +82,8 @@ _uav = "b_uav";			// UAV
 #include "f_setLocalGroupMarkers_Indfor.sqf"
 
 // ====================================================================================
+
+// MARKERS: ALL
+// Markers spawned here can be seen by all units
+
+// ====================================================================================

--- a/f/groupMarkers/f_setLocalGroupMarkers_Blufor.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers_Blufor.sqf
@@ -3,10 +3,9 @@
 // ====================================================================================
 
 // MARKERS: BLUFOR > NATO
-// Markers seen by players in NATO slots.
+// Markers seen by players in NATO & NATO (Pacific) slots.
 
-case "blu_f":
-{
+if (_unitfaction in ["blu_f","blu_t_f"]) then {
 	["GrpNATO_CO",_hq, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
 	["GrpNATO_DC",_hq, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
 	["GrpNATO_COV",_ifv, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
@@ -64,7 +63,6 @@ case "blu_f":
 	["UnitNATO_ASL_M",_med, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
 	["UnitNATO_BSL_M",_med, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
 	["UnitNATO_CSL_M",_med, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-
 };
 
 // ====================================================================================
@@ -72,8 +70,7 @@ case "blu_f":
 // MARKERS: BLUFOR > FIA
 // Markers seen by players in FIA slots.
 
-case "blu_g_f":
-{
+if (_unitfaction in ["blu_g_f"]) then {
 	["GrpFIA_CO",_hq, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
 	["GrpFIA_DC",_hq, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
 	["GrpFIA_COV",_ifv, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
@@ -131,7 +128,6 @@ case "blu_g_f":
 	["UnitFIA_ASL_M",_med, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
 	["UnitFIA_BSL_M",_med, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
 	["UnitFIA_CSL_M",_med, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-
 };
 
 // ====================================================================================

--- a/f/groupMarkers/f_setLocalGroupMarkers_Indfor.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers_Indfor.sqf
@@ -5,8 +5,7 @@
 // MARKERS: INDEPEDENT > AAF
 // Markers seen by players in AAF slots.
 
-case "ind_f":
-{
+if (_unitfaction in ["ind_f"]) then {
 	["GrpAAF_CO",_hq, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
 	["GrpAAF_DC",_hq, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
 	["GrpAAF_COV",_ifv, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
@@ -67,8 +66,7 @@ case "ind_f":
 // MARKERS: INDEPENDENT > FIA
 // Markers seen by players in INDEPENDENT-FIA slots.
 
-case "ind_g_f":
-{
+if (_unitfaction in ["ind_g_f"]) then {
 	["GrpIFIA_CO",_hq, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
 	["GrpIFIA_DC",_hq, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
 	["GrpIFIA_COV",_ifv, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
@@ -126,7 +124,6 @@ case "ind_g_f":
 	["UnitIFIA_ASL_M",_med, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
 	["UnitIFIA_BSL_M",_med, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
 	["UnitIFIA_CSL_M",_med, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-
 };
 
 // ====================================================================================
@@ -134,8 +131,7 @@ case "ind_g_f":
 // MARKERS: INDEPENDENT > SYNDIKAT
 // Markers seen by players in SYNDIKAT slots.
 
-case "ind_c_f":
-{
+if (_unitfaction in ["ind_c_f"]) then {
 	["GrpSyn_CO",_hq, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
 	["GrpSyn_DC",_hq, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
 	["GrpSyn_COV",_ifv, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
@@ -193,7 +189,6 @@ case "ind_c_f":
 	["UnitSyn_ASL_M",_med, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
 	["UnitSyn_BSL_M",_med, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
 	["UnitSyn_CSL_M",_med, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-
 };
 
 // ====================================================================================

--- a/f/groupMarkers/f_setLocalGroupMarkers_Opfor.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers_Opfor.sqf
@@ -3,10 +3,9 @@
 // ====================================================================================
 
 // MARKERS: OPFOR > CSAT
-// Markers seen by players in CSAT slots.
+// Markers seen by players in CSAT & CSAT (Pacific) slots.
 
-case "opf_f":
-{
+if (_unitfaction in ["opf_f","opf_t_f"]) then {
 	["GrpCSAT_CO",_hq, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
 	["GrpCSAT_DC",_hq, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
 	["GrpCSAT_COV",_ifv, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
@@ -71,8 +70,7 @@ case "opf_f":
 // MARKERS: OPFOR > FIA
 // Markers seen by players in OPFOR-FIA slots.
 
-case "opf_g_f":
-{
+if (_unitfaction in ["opf_g_f"]) then {
 	["GrpOFIA_CO",_hq, "CO", "ColorYellow"] spawn f_fnc_localGroupMarker;
 	["GrpOFIA_DC",_hq, "DC", "ColorYellow"] spawn f_fnc_localGroupMarker;
 	["GrpOFIA_COV",_ifv, "COV", "ColorYellow"] spawn f_fnc_localGroupMarker;
@@ -130,7 +128,6 @@ case "opf_g_f":
 	["UnitOFIA_ASL_M",_med, "AM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
 	["UnitOFIA_BSL_M",_med, "BM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
 	["UnitOFIA_CSL_M",_med, "CM", "ColorBlack"] spawn f_fnc_localSpecialistMarker;
-
 };
 
 // ====================================================================================

--- a/f/setGroupID/f_setGroupIDs.sqf
+++ b/f/setGroupID/f_setGroupIDs.sqf
@@ -177,62 +177,6 @@ _groups = [
 
 // ====================================================================================
 
-// GROUP IDs: INDEPENDENT > SYNDIKAT
-// Automatically assigns intelligible names to groups
-
-["GrpSyn_CO","AAF CO -"],
-["GrpSyn_DC","AAF DC -"],
-["GrpSyn_COV","AAF COV -"],
-
-["GrpSyn_ASL","AAF ASL -"],
-["GrpSyn_A1","AAF A1 -"],
-["GrpSyn_A2","AAF A2 -"],
-["GrpSyn_AV","AAF AV -"],
-
-["GrpSyn_BSL","AAF BSL -"],
-["GrpSyn_B1","AAF B1 -"],
-["GrpSyn_B2","AAF B2 -"],
-["GrpSyn_BV","AAF BV -"],
-
-["GrpSyn_CSL","AAF CSL -"],
-["GrpSyn_C1","AAF C1 -"],
-["GrpSyn_C2","AAF C2 -"],
-["GrpSyn_CV","AAF CV -"],
-
-["GrpSyn_JSL","AAF JSL -"],
-["GrpSyn_J1","AAF J1 -"],
-["GrpSyn_J2","AAF J2 -"],
-["GrpSyn_JV","AAF JV -"],
-
-["GrpSyn_MMG1","AAF MMG1 -"],
-["GrpSyn_MMG2","AAF MMG2 -"],
-["GrpSyn_HMG1","AAF HMG1 -"],
-["GrpSyn_MAT1","AAF MAT1 -"],
-["GrpSyn_MAT2","AAF MAT2 -"],
-["GrpSyn_HAT1","AAF HAT1 -"],
-["GrpSyn_MTR1","AAF MTR1 -"],
-["GrpSyn_MSAM1","AAF MSAM1 -"],
-["GrpSyn_HSAM1","AAF HSAM1 -"],
-["GrpSyn_ST1","AAF ST1 -"],
-["GrpSyn_DT1","AAF DT1 -"],
-["GrpSyn_ENG1","AAF ENG1 -"],
-
-["GrpSyn_IFV1","AAF IFV1 -"],
-["GrpSyn_IFV2","AAF IFV2 -"],
-["GrpSyn_TNK1","AAF TNK1 -"],
-
-["GrpSyn_TH1","AAF TH1 -"],
-["GrpSyn_TH2","AAF TH2 -"],
-["GrpSyn_TH3","AAF TH3 -"],
-["GrpSyn_TH4","AAF TH4 -"],
-["GrpSyn_TH5","AAF TH5 -"],
-["GrpSyn_TH6","AAF TH6 -"],
-["GrpSyn_TH7","AAF TH7 -"],
-["GrpSyn_TH8","AAF TH8 -"],
-["GrpSyn_AH1","AAF AH1 -"],
-
-// ====================================================================================
-
 // GROUP IDs: OPFOR > FIA
 // Automatically assigns intelligible names to groups
 
@@ -343,10 +287,65 @@ _groups = [
 ["GrpAAF_TH8","AAF TH8 -"],
 ["GrpAAF_AH1","AAF AH1 -"],
 
+// ====================================================================================
+
+// GROUP IDs: INDEPENDENT > SYNDIKAT
+// Automatically assigns intelligible names to groups
+
+["GrpSyn_CO","AAF CO -"],
+["GrpSyn_DC","AAF DC -"],
+["GrpSyn_COV","AAF COV -"],
+
+["GrpSyn_ASL","AAF ASL -"],
+["GrpSyn_A1","AAF A1 -"],
+["GrpSyn_A2","AAF A2 -"],
+["GrpSyn_AV","AAF AV -"],
+
+["GrpSyn_BSL","AAF BSL -"],
+["GrpSyn_B1","AAF B1 -"],
+["GrpSyn_B2","AAF B2 -"],
+["GrpSyn_BV","AAF BV -"],
+
+["GrpSyn_CSL","AAF CSL -"],
+["GrpSyn_C1","AAF C1 -"],
+["GrpSyn_C2","AAF C2 -"],
+["GrpSyn_CV","AAF CV -"],
+
+["GrpSyn_JSL","AAF JSL -"],
+["GrpSyn_J1","AAF J1 -"],
+["GrpSyn_J2","AAF J2 -"],
+["GrpSyn_JV","AAF JV -"],
+
+["GrpSyn_MMG1","AAF MMG1 -"],
+["GrpSyn_MMG2","AAF MMG2 -"],
+["GrpSyn_HMG1","AAF HMG1 -"],
+["GrpSyn_MAT1","AAF MAT1 -"],
+["GrpSyn_MAT2","AAF MAT2 -"],
+["GrpSyn_HAT1","AAF HAT1 -"],
+["GrpSyn_MTR1","AAF MTR1 -"],
+["GrpSyn_MSAM1","AAF MSAM1 -"],
+["GrpSyn_HSAM1","AAF HSAM1 -"],
+["GrpSyn_ST1","AAF ST1 -"],
+["GrpSyn_DT1","AAF DT1 -"],
+["GrpSyn_ENG1","AAF ENG1 -"],
+
+["GrpSyn_IFV1","AAF IFV1 -"],
+["GrpSyn_IFV2","AAF IFV2 -"],
+["GrpSyn_TNK1","AAF TNK1 -"],
+
+["GrpSyn_TH1","AAF TH1 -"],
+["GrpSyn_TH2","AAF TH2 -"],
+["GrpSyn_TH3","AAF TH3 -"],
+["GrpSyn_TH4","AAF TH4 -"],
+["GrpSyn_TH5","AAF TH5 -"],
+["GrpSyn_TH6","AAF TH6 -"],
+["GrpSyn_TH7","AAF TH7 -"],
+["GrpSyn_TH8","AAF TH8 -"],
+["GrpSyn_AH1","AAF AH1 -"],
 
 // ====================================================================================
 
-// GROUP IDs: OPFOR > FIA
+// GROUP IDs: Independent > FIA
 // Automatically assigns intelligible names to groups
 
 ["GrpIFIA_CO","FIA I CO -"],

--- a/mission.sqm
+++ b/mission.sqm
@@ -8,14 +8,14 @@ class EditorData
 	toggles=2;
 	class ItemIDProvider
 	{
-		nextID=1027;
+		nextID=1030;
 	};
 	class Camera
 	{
-		pos[]={10408.537,188.45818,11075.876};
-		dir[]={0.22025281,-0.22272371,0.94979221};
-		up[]={0.050359514,0.9748227,0.21716273};
-		aside[]={0.97424382,-9.9185854e-008,-0.22592425};
+		pos[]={11537.996,47.302635,12630.831};
+		dir[]={0,-0.70710683,0.70710683};
+		up[]={0,0.70710677,0.70710677};
+		aside[]={0.99999994,0,-0};
 	};
 };
 binarizationWanted=0;
@@ -51,8 +51,8 @@ addons[]=
 	"A3_Modules_F_Supports",
 	"A3_Characters_F",
 	"A3_Static_F_Mortar_01",
-	"A3_Characters_F_Exp",
 	"A3_Data_F_Curator_Virtual",
+	"A3_Characters_F_Exp",
 	"A3_Soft_F_Exp_Offroad_02",
 	"A3_Soft_F_Exp_Van_01"
 };
@@ -175,15 +175,15 @@ class AddonsMetaData
 		};
 		class Item16
 		{
-			className="A3_Characters_F_Exp";
-			name="Arma 3 Apex - Characters and Clothing";
+			className="A3_Data_F_Curator";
+			name="Arma 3 Zeus Update - Main Configuration";
 			author="Bohemia Interactive";
 			url="http://www.arma3.com";
 		};
 		class Item17
 		{
-			className="A3_Data_F_Curator";
-			name="Arma 3 Zeus Update - Main Configuration";
+			className="A3_Characters_F_Exp";
+			name="Arma 3 Apex - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="http://www.arma3.com";
 		};
@@ -694,7 +694,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={11662.302,24.486202,12574.99};
+				position[]={11662.302,24.485853,12574.99};
 				angles[]={0.025324726,0,6.2738476};
 			};
 			side="East";
@@ -708,7 +708,7 @@ class Mission
 			};
 			id=21;
 			type="O_Heli_Light_02_unarmed_F";
-			atlOffset=0.00035095215;
+			atlOffset=1.9073486e-006;
 		};
 		class Item22
 		{
@@ -16762,7 +16762,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={11662.503,22.332611,12574.853};
+						position[]={11662.281,22.315632,12575.096};
 						angles[]={0.025324726,0,6.2738476};
 					};
 					side="East";
@@ -16778,14 +16778,14 @@ class Mission
 					};
 					id=511;
 					type="O_helipilot_F";
-					atlOffset=0.012887955;
+					atlOffset=1.9073486e-006;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={11662.503,22.332611,12574.853};
+						position[]={11662.281,22.315632,12575.096};
 						angles[]={0.025324726,0,6.2738476};
 					};
 					side="East";
@@ -16801,7 +16801,7 @@ class Mission
 					};
 					id=512;
 					type="O_soldier_repair_F";
-					atlOffset=0.012887955;
+					atlOffset=1.9073486e-006;
 				};
 			};
 			class Attributes
@@ -16841,7 +16841,7 @@ class Mission
 				};
 			};
 			id=510;
-			atlOffset=0.00035095215;
+			atlOffset=1.9073486e-006;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29767,7 +29767,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={10415.064,15.371277,12618.746};
+						position[]={10415.244,15.515533,12618.855};
 						angles[]={6.2272477,0,0.01733112};
 					};
 					side="Independent";
@@ -29782,7 +29782,7 @@ class Mission
 					};
 					id=940;
 					type="I_C_Helipilot_F";
-					atlOffset=-0.13497734;
+					atlOffset=9.5367432e-007;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -29812,7 +29812,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={10415.064,15.371277,12618.746};
+						position[]={10415.244,15.515533,12618.855};
 						angles[]={6.2272477,0,0.01733112};
 					};
 					side="Independent";
@@ -29827,7 +29827,7 @@ class Mission
 					};
 					id=941;
 					type="I_C_Helipilot_F";
-					atlOffset=-0.13497734;
+					atlOffset=9.5367432e-007;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -29870,7 +29870,7 @@ class Mission
 					{
 						linkID=0;
 						item0=940;
-						item1=942;
+						item1=1027;
 						class CustomData
 						{
 							role=1;
@@ -29880,7 +29880,7 @@ class Mission
 					{
 						linkID=1;
 						item0=941;
-						item1=942;
+						item1=1027;
 						class CustomData
 						{
 							role=2;
@@ -29890,7 +29890,7 @@ class Mission
 				};
 			};
 			id=939;
-			atlOffset=0.00037193298;
+			atlOffset=1.9073486e-006;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29916,26 +29916,6 @@ class Mission
 			};
 		};
 		class Item317
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={10415.234,16.063354,12617.793};
-				angles[]={6.2272477,0,0.01733112};
-			};
-			side="Independent";
-			flags=6;
-			class Attributes
-			{
-				skill=0.60000002;
-				init="[""v_helo_l"",this] call f_fnc_assignGear";
-				name="VehSyn_TH1_1";
-			};
-			id=942;
-			type="C_Heli_Light_01_civil_F";
-			atlOffset=0.00037193298;
-		};
-		class Item318
 		{
 			dataType="Group";
 			side="Independent";
@@ -30094,7 +30074,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item319
+		class Item318
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30115,7 +30095,7 @@ class Mission
 			type="B_G_Offroad_01_armed_F";
 			atlOffset=6.4849854e-005;
 		};
-		class Item320
+		class Item319
 		{
 			dataType="Group";
 			side="Independent";
@@ -30273,7 +30253,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item321
+		class Item320
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30294,7 +30274,7 @@ class Mission
 			type="B_G_Offroad_01_armed_F";
 			atlOffset=-1.1444092e-005;
 		};
-		class Item322
+		class Item321
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30314,7 +30294,7 @@ class Mission
 			id=951;
 			type="I_C_Offroad_02_unarmed_F";
 		};
-		class Item323
+		class Item322
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30334,7 +30314,7 @@ class Mission
 			id=952;
 			type="I_C_Offroad_02_unarmed_F";
 		};
-		class Item324
+		class Item323
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30354,7 +30334,7 @@ class Mission
 			id=953;
 			type="I_C_Van_01_transport_F";
 		};
-		class Item325
+		class Item324
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30374,7 +30354,7 @@ class Mission
 			id=954;
 			type="I_C_Van_01_transport_F";
 		};
-		class Item326
+		class Item325
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30394,7 +30374,7 @@ class Mission
 			id=955;
 			type="I_C_Van_01_transport_F";
 		};
-		class Item327
+		class Item326
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30414,7 +30394,7 @@ class Mission
 			id=956;
 			type="I_C_Van_01_transport_F";
 		};
-		class Item328
+		class Item327
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30435,7 +30415,7 @@ class Mission
 			type="I_C_Van_01_transport_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item329
+		class Item328
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30455,7 +30435,7 @@ class Mission
 			id=958;
 			type="I_C_Van_01_transport_F";
 		};
-		class Item330
+		class Item329
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30476,7 +30456,7 @@ class Mission
 			type="I_C_Offroad_02_unarmed_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item331
+		class Item330
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30496,7 +30476,7 @@ class Mission
 			id=960;
 			type="I_C_Offroad_02_unarmed_F";
 		};
-		class Item332
+		class Item331
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30538,7 +30518,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item333
+		class Item332
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30580,7 +30560,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item334
+		class Item333
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30623,7 +30603,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item335
+		class Item334
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -30772,7 +30752,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item336
+		class Item335
 		{
 			dataType="Group";
 			side="Independent";
@@ -30898,7 +30878,7 @@ class Mission
 			id=965;
 			atlOffset=-1.9073486e-006;
 		};
-		class Item337
+		class Item336
 		{
 			dataType="Object";
 			class PositionInfo
@@ -30917,7 +30897,7 @@ class Mission
 			type="I_Heli_light_03_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item338
+		class Item337
 		{
 			dataType="Group";
 			side="Independent";
@@ -30992,7 +30972,7 @@ class Mission
 			id=969;
 			atlOffset=-1.9073486e-006;
 		};
-		class Item339
+		class Item338
 		{
 			dataType="Object";
 			class PositionInfo
@@ -31009,7 +30989,7 @@ class Mission
 			type="I_Mortar_01_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item340
+		class Item339
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -31101,7 +31081,7 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item341
+		class Item340
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -31112,7 +31092,7 @@ class Mission
 			id=973;
 			type="SupportProvider_Artillery";
 		};
-		class Item342
+		class Item341
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -31261,7 +31241,7 @@ class Mission
 				nAttributes=7;
 			};
 		};
-		class Item343
+		class Item342
 		{
 			dataType="Group";
 			side="Independent";
@@ -31386,7 +31366,7 @@ class Mission
 			};
 			id=975;
 		};
-		class Item344
+		class Item343
 		{
 			dataType="Object";
 			class PositionInfo
@@ -31404,7 +31384,7 @@ class Mission
 			id=978;
 			type="I_Heli_light_03_F";
 		};
-		class Item345
+		class Item344
 		{
 			dataType="Group";
 			side="Independent";
@@ -31478,7 +31458,7 @@ class Mission
 			};
 			id=979;
 		};
-		class Item346
+		class Item345
 		{
 			dataType="Object";
 			class PositionInfo
@@ -31495,7 +31475,7 @@ class Mission
 			id=981;
 			type="I_Mortar_01_F";
 		};
-		class Item347
+		class Item346
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -31587,7 +31567,7 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item348
+		class Item347
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -31597,6 +31577,26 @@ class Mission
 			};
 			id=983;
 			type="SupportProvider_Artillery";
+		};
+		class Item348
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={10415.212,17.373997,12618.702};
+				angles[]={6.2272477,0,0.01733112};
+			};
+			side="Independent";
+			flags=6;
+			class Attributes
+			{
+				skill=0.60000002;
+				init="[""v_helo_l"",this,""syndikat""] call f_fnc_assignGear";
+				name="VehSyn_TH1_1";
+			};
+			id=1027;
+			type="I_Heli_light_03_unarmed_F";
+			atlOffset=1.9073486e-006;
 		};
 	};
 	class Connections


### PR DESCRIPTION
* Added dummy gear files for NATO & CSAT pacific (natopacific.sqf & csatpacific.sqf)
* Added briefing file for CTRG

Reworked assignGear function:
 - all if checks now compare the faction to an array of possible factions instead of a single comparison
 - strings such as "aaf", "nato" etc. can now be used when forcing a specific faction loadout (instead of having to use the precise faction string, such as "ind_f")

Reword groupMarker component:
 - changed switch structure to several if-checks. Benefit: Easier to show the same marker to several units/factions (you only need to add a single string instead of copying the entire block of code)
 - NATO & CSAT (Pacific) are shown the default GrpNATO/GrpCSAT markers

Updated briefing.sqf
 - all if checks now compare the faction to an array of possible factions instead of a single comparison
 - NATO & CSAT (Pacific) are both referred to the regular briefing_nato/_csat.sqf